### PR TITLE
Add new state LockDoorStatus.DISABLED for when doorsense is explicitly disabled

### DIFF
--- a/tests/fixtures/get_lock.online_with_doorsense_disabled.json
+++ b/tests/fixtures/get_lock.online_with_doorsense_disabled.json
@@ -1,0 +1,51 @@
+{
+   "Bridge" : {
+      "_id" : "bridgeid",
+      "deviceModel" : "august-connect",
+      "firmwareVersion" : "2.2.1",
+      "hyperBridge" : true,
+      "mfgBridgeID" : "C5WY200WSH",
+      "operative" : true,
+      "status" : {
+         "current" : "online",
+         "lastOffline" : "2000-00-00T00:00:00.447Z",
+         "lastOnline" : "2000-00-00T00:00:00.447Z",
+         "updated" : "2000-00-00T00:00:00.447Z"
+      }
+   },
+   "Calibrated" : false,
+   "Created" : "2000-00-00T00:00:00.447Z",
+   "HouseID" : "123",
+   "HouseName" : "Test",
+   "LockID" : "ABC",
+   "LockName" : "Online door with doorsense disabled",
+   "LockStatus" : {
+      "dateTime" : "2017-12-10T04:48:30.272Z",
+      "doorState" : "",
+      "isLockStatusChanged" : false,
+      "status" : "locked",
+      "valid" : true
+   },
+   "SerialNumber" : "XY",
+   "Type" : 1001,
+   "Updated" : "2000-00-00T00:00:00.447Z",
+   "battery" : 0.922,
+   "currentFirmwareVersion" : "undefined-4.3.0-1.8.14",
+   "homeKitEnabled" : true,
+   "hostLockInfo" : {
+      "manufacturer" : "yale",
+      "productID" : 1536,
+      "productTypeID" : 32770,
+      "serialNumber" : "ABC"
+   },
+   "isGalileo" : false,
+   "macAddress" : "12:22",
+   "pins" : {
+      "created" : [],
+      "loaded" : []
+   },
+   "skuNumber" : "AUG-MD01",
+   "supportsEntryCodes" : true,
+   "timeZone" : "Pacific/Hawaii",
+   "zWaveEnabled" : false
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -328,7 +328,7 @@ class TestApi(unittest.TestCase):
         self.assertEqual(False, lock.doorsense)
 
         self.assertEqual(LockStatus.UNKNOWN, lock.lock_status)
-        self.assertEqual(LockDoorStatus.UNKNOWN, lock.door_state)
+        self.assertEqual(LockDoorStatus.DISABLED, lock.door_state)
         self.assertEqual(None, lock.lock_status_datetime)
         self.assertEqual(None, lock.door_state_datetime)
 
@@ -359,7 +359,7 @@ class TestApi(unittest.TestCase):
         self.assertEqual(False, lock.doorsense)
 
         self.assertEqual(LockStatus.LOCKED, lock.lock_status)
-        self.assertEqual(LockDoorStatus.UNKNOWN, lock.door_state)
+        self.assertEqual(LockDoorStatus.DISABLED, lock.door_state)
         self.assertEqual(
             dateutil.parser.parse("2017-12-10T04:48:30.272Z"), lock.lock_status_datetime
         )

--- a/tests/test_api_async.py
+++ b/tests/test_api_async.py
@@ -266,6 +266,42 @@ class TestApiAsync(aiounittest.AsyncTestCase):
         )
 
     @aioresponses()
+    async def test_async_get_lock_detail_with_doorsense_disabled_bridge_online(
+        self, mock
+    ):
+        mock.get(
+            API_GET_LOCK_URL.format(lock_id="ABC"),
+            body=load_fixture("get_lock.online_with_doorsense_disabled.json"),
+        )
+
+        api = ApiAsync(ClientSession())
+        lock = await api.async_get_lock_detail(ACCESS_TOKEN, "ABC")
+
+        self.assertEqual("ABC", lock.device_id)
+        self.assertEqual("Online door with doorsense disabled", lock.device_name)
+        self.assertEqual("123", lock.house_id)
+        self.assertEqual("XY", lock.serial_number)
+        self.assertEqual("undefined-4.3.0-1.8.14", lock.firmware_version)
+        self.assertEqual(92, lock.battery_level)
+        self.assertEqual("AUG-MD01", lock.model)
+        self.assertEqual(None, lock.keypad)
+        self.assertIsInstance(lock.bridge, BridgeDetail)
+        self.assertIsInstance(lock.bridge.status, BridgeStatusDetail)
+        self.assertEqual(BridgeStatus.ONLINE, lock.bridge.status.current)
+        self.assertEqual(True, lock.bridge_is_online)
+        self.assertEqual(True, lock.bridge.operative)
+        self.assertEqual(False, lock.doorsense)
+
+        self.assertEqual(LockStatus.LOCKED, lock.lock_status)
+        self.assertEqual(LockDoorStatus.DISABLED, lock.door_state)
+        self.assertEqual(
+            dateutil.parser.parse("2017-12-10T04:48:30.272Z"), lock.lock_status_datetime
+        )
+        self.assertEqual(
+            dateutil.parser.parse("2017-12-10T04:48:30.272Z"), lock.door_state_datetime
+        )
+
+    @aioresponses()
     async def test_async_get_lock_detail_bridge_online(self, mock):
         mock.get(
             API_GET_LOCK_URL.format(lock_id="A6697750D607098BAE8D6BAA11EF8063"),
@@ -324,7 +360,7 @@ class TestApiAsync(aiounittest.AsyncTestCase):
         self.assertEqual(False, lock.doorsense)
 
         self.assertEqual(LockStatus.UNKNOWN, lock.lock_status)
-        self.assertEqual(LockDoorStatus.UNKNOWN, lock.door_state)
+        self.assertEqual(LockDoorStatus.DISABLED, lock.door_state)
         self.assertEqual(None, lock.lock_status_datetime)
         self.assertEqual(None, lock.door_state_datetime)
 
@@ -356,7 +392,7 @@ class TestApiAsync(aiounittest.AsyncTestCase):
         self.assertEqual(False, lock.doorsense)
 
         self.assertEqual(LockStatus.LOCKED, lock.lock_status)
-        self.assertEqual(LockDoorStatus.UNKNOWN, lock.door_state)
+        self.assertEqual(LockDoorStatus.DISABLED, lock.door_state)
         self.assertEqual(
             dateutil.parser.parse("2017-12-10T04:48:30.272Z"), lock.lock_status_datetime
         )

--- a/tests/test_pubnub_activity.py
+++ b/tests/test_pubnub_activity.py
@@ -35,7 +35,7 @@ class TestLockDetail(unittest.TestCase):
         lock = LockDetail(json.loads(load_fixture("get_lock.doorsense_init.json")))
         self.assertEqual("A6697750D607098BAE8D6BAA11EF8063", lock.device_id)
         self.assertEqual(LockStatus.LOCKED, lock.lock_status)
-        self.assertEqual(LockDoorStatus.UNKNOWN, lock.door_state)
+        self.assertEqual(LockDoorStatus.DISABLED, lock.door_state)
 
         activities = activities_from_pubnub_message(
             lock,

--- a/yalexs/api_common.py
+++ b/yalexs/api_common.py
@@ -88,7 +88,7 @@ def _convert_lock_result_to_activities(lock_json_dict):
     activities.append(activity_lock_dict)
 
     door_state = determine_door_state(lock_json_dict.get("doorState"))
-    if door_state != LockDoorStatus.UNKNOWN:
+    if door_state not in (LockDoorStatus.UNKNOWN, LockDoorStatus.DISABLED):
         activity_door_dict = _map_lock_result_to_activity(
             lock_id, activity_epoch, door_state_to_string(door_state)
         )

--- a/yalexs/lock.py
+++ b/yalexs/lock.py
@@ -18,6 +18,7 @@ JAMMED_STATUS = (
 
 CLOSED_STATUS = ("closed", "kAugLockDoorState_Closed", "kAugDoorState_Closed")
 OPEN_STATUS = ("open", "kAugLockDoorState_Open", "kAugDoorState_Open")
+DISABLE_STATUS = ("init", "", None)
 
 LOCK_STATUS_KEY = "status"
 DOOR_STATE_KEY = "doorState"
@@ -79,7 +80,7 @@ class LockDetail(DeviceDetail):
 
             if (
                 DOOR_STATE_KEY in lock_status
-                and self._door_state != LockDoorStatus.UNKNOWN
+                and self._door_state != LockDoorStatus.DISABLED
             ):
                 self._doorsense = True
 
@@ -206,6 +207,7 @@ class LockDoorStatus(Enum):
     CLOSED = "closed"
     OPEN = "open"
     UNKNOWN = "unknown"
+    DISABLED = "disabled"
 
 
 def determine_lock_status(status):
@@ -227,6 +229,8 @@ def determine_door_state(status):
         return LockDoorStatus.CLOSED
     if status in OPEN_STATUS:
         return LockDoorStatus.OPEN
+    if status in DISABLE_STATUS:
+        return LockDoorStatus.DISABLED
     return LockDoorStatus.UNKNOWN
 
 


### PR DESCRIPTION
- If doorsense was not available or updating at startup, we would incorrectly
  believe it as not installed and would not make it available until the next
  restart