### PR TITLE
Guard against empty pubnub callback on disconnect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
         "python-dateutil",
         "aiohttp",
         "aiofiles",
-        "pubnub>=5.1.4",
+        "pubnub>=5.5.0",
     ],
 )

--- a/yalexs/pubnub_async.py
+++ b/yalexs/pubnub_async.py
@@ -24,6 +24,10 @@ class AugustPubNub(SubscribeCallback):
         _LOGGER.debug("Recieved new presence: %s", presence)
 
     def status(self, pubnub, status):
+        if not pubnub:
+            self.connected = False
+            return
+
         _LOGGER.debug(
             "Recieved new status: category=%s error_data=%s error=%s status_code=%s operation=%s",
             status.category,


### PR DESCRIPTION
Fixes
```
2021-12-23 11:18:04 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/pubnub/pubnub_asyncio.py", line 531, in _send_leave_helper
self._listener_manager.announce_status(envelope.status)
File "/usr/local/lib/python3.9/site-packages/pubnub/managers.py", line 194, in announce_status
callback.status(self._pubnub, status)
File "/usr/local/lib/python3.9/site-packages/yalexs/pubnub_async.py", line 29, in status
status.category,
AttributeError: 'NoneType' object has no attribute 'category'
```