### PR TITLE
Handling secure mode

### DIFF
--- a/yalexs/lock.py
+++ b/yalexs/lock.py
@@ -7,7 +7,7 @@ from yalexs.bridge import BridgeDetail, BridgeStatus
 from yalexs.device import Device, DeviceDetail
 from yalexs.keypad import KeypadDetail
 
-LOCKED_STATUS = ("locked", "kAugLockState_Locked")
+LOCKED_STATUS = ("locked", "kAugLockState_Locked", "kAugLockState_SecureMode")
 LOCKING_STATUS = ("kAugLockState_Locking",)
 UNLOCKED_STATUS = ("unlocked", "kAugLockState_Unlocked")
 UNLOCKING_STATUS = ("kAugLockState_Unlocking",)


### PR DESCRIPTION
When setting the lock in "secure mode" (cannot be physically opened from the inside) august reports `kAugLockState_SecureMode`. This isn't interpenetrated as locked.

This change proposes to change that.