### PR TITLE
Add names to local lock operations for compat

### DIFF
--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import json
 import os
 import unittest
@@ -255,9 +254,6 @@ class TestActivity(unittest.TestCase):
         )
         assert remote_unlock_activity.activity_type == ActivityType.LOCK_OPERATION
         assert remote_unlock_activity.operated_by == "Zipper Zoomer"
-        assert remote_unlock_activity.activity_start_time == datetime(
-            2022, 10, 11, 12, 58, 23, 770000
-        )
         assert remote_unlock_activity.operated_remote is True
         assert remote_unlock_activity.operated_keypad is False
         assert (

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,13 +1,11 @@
 from datetime import datetime
 import json
 import os
-from time import timezone
 import unittest
 
 from aiohttp import ClientSession
 from aioresponses import aioresponses
 import aiounittest
-from dateutil.tz import tzlocal, tzutc
 
 from yalexs.activity import (
     ACTION_BRIDGE_OFFLINE,

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -166,7 +166,7 @@ class TestActivity(unittest.TestCase):
         auto_lock_activity = LockOperationActivity(
             SOURCE_LOG, json.loads(load_fixture("auto_lock_activity.json"))
         )
-        assert auto_lock_activity.operated_by is None
+        assert auto_lock_activity.operated_by == "Auto Lock"
         assert auto_lock_activity.operated_remote is False
         assert auto_lock_activity.operated_keypad is False
         assert (
@@ -275,7 +275,7 @@ class TestActivity(unittest.TestCase):
         manual_lock_activity = LockOperationActivity(
             SOURCE_LOG, json.loads(load_fixture("manual_lock_activity.json"))
         )
-        assert manual_lock_activity.operated_by is None
+        assert manual_lock_activity.operated_by == "Manual Lock"
         assert manual_lock_activity.operated_remote is False
         assert manual_lock_activity.operated_keypad is False
         assert (
@@ -291,7 +291,7 @@ class TestActivity(unittest.TestCase):
         manual_unlock_activity = LockOperationActivity(
             SOURCE_LOG, json.loads(load_fixture("manual_unlock_activity.json"))
         )
-        assert manual_unlock_activity.operated_by is None
+        assert manual_unlock_activity.operated_by == "Manual Unlock"
         assert manual_unlock_activity.operated_remote is False
         assert manual_unlock_activity.operated_keypad is False
         assert (

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -71,6 +71,22 @@ ACTIVITY_ACTIONS_LOCK_OPERATION = {
     ACTION_LOCK_MANUAL_LOCK,
     ACTION_LOCK_MANUAL_UNLOCK,
 }
+
+
+ACTIVITY_TO_FIRST_LAST_NAME = {
+    ACTION_RF_SECURE: ("Radio Frequency", "Secure"),
+    ACTION_RF_LOCK: ("Radio Frequency", "Lock"),
+    ACTION_RF_UNLOCK: ("Radio Frequency", "Unlock"),
+    ACTION_LOCK_AUTO_LOCK: ("Auto", "Lock"),
+    ACTION_LOCK_ONETOUCHLOCK: ("One-Touch", "Lock"),
+    ACTION_LOCK_ONETOUCHLOCK_2: ("One-Touch", "Lock"),
+    ACTION_LOCK_BLE_LOCK: ("Bluetooth", "Lock"),
+    ACTION_LOCK_BLE_UNLOCK: ("Bluetooth", "Unlock"),
+    ACTION_LOCK_MANUAL_LOCK: ("Manual", "Lock"),
+    ACTION_LOCK_MANUAL_UNLOCK: ("Manual", "Unlock"),
+}
+
+
 ACTIVITY_ACTIONS_DOOR_OPERATION = {
     ACTION_DOOR_CLOSED,
     ACTION_DOOR_OPEN,
@@ -299,6 +315,15 @@ class LockOperationActivity(Activity):
         if yale_user and first_name is None and last_name is None:
             first_name = yale_user.first_name
             last_name = yale_user.last_name
+
+        # For legacy compatibility, we need to set the first_name and last_name
+        # if its a physical or rf lock operation
+        if (
+            first_name is None
+            and last_name is None
+            and action in ACTIVITY_TO_FIRST_LAST_NAME
+        ):
+            first_name, last_name = ACTIVITY_TO_FIRST_LAST_NAME[action]
 
         if first_name is None and last_name is None:
             self._operated_by = None


### PR DESCRIPTION
The old api set the last/first name fields for these
operations so we need to do so as well for back-compat