### PR TITLE
Revert "Avoid setting the operator if the lock event is a replay (#56)"

### DIFF
--- a/tests/test_pubnub_activity.py
+++ b/tests/test_pubnub_activity.py
@@ -200,10 +200,8 @@ class TestLockDetail(unittest.TestCase):
         )
         assert isinstance(activities[0], LockOperationActivity)
         assert activities[0].action == "lock"
-        assert activities[0].operated_by is None
-        assert (
-            activities[0].activity_type == ActivityType.LOCK_OPERATION_WITHOUT_OPERATOR
-        )
+        assert activities[0].operated_by == "Foo Bar"
+        assert activities[0].activity_type == ActivityType.LOCK_OPERATION
         assert isinstance(activities[1], DoorOperationActivity)
         assert activities[1].action == "doorclosed"
 
@@ -265,21 +263,6 @@ class TestLockDetail(unittest.TestCase):
                 "status": "unlocked",
                 "callingUserID": "5309b78d-de0c-4ec5-b878-02784c3b598a",
                 "doorState": "closed",
-                "info": {
-                    "action": "unlock",
-                    "startTime": "2017-12-10T05:48:30.272Z",
-                    "context": {
-                        "transactionID": "_oJRZKJsx",
-                        "startDate": "2017-12-10T05:48:30.272Z",
-                        "retryCount": 1,
-                    },
-                    "lockType": "lock_version_1001",
-                    "serialNumber": "M1FBA029QJ",
-                    "rssi": -53,
-                    "wlanRSSI": -55,
-                    "wlanSNR": 44,
-                    "duration": 2534,
-                },
             },
         )
         assert isinstance(activities[0], LockOperationActivity)

--- a/yalexs/pubnub_activity.py
+++ b/yalexs/pubnub_activity.py
@@ -44,13 +44,10 @@ def activities_from_pubnub_message(
     }
     info = message.get("info", {})
     context = info.get("context", {})
-    accept_user = False
     if "startDate" in context:
         activity_dict["dateTime"] = _datetime_string_to_epoch(context["startDate"])
-        accept_user = True
     elif "startTime" in info:
         activity_dict["dateTime"] = _datetime_string_to_epoch(info["startTime"])
-        accept_user = True
     else:
         activity_dict["dateTime"] = date_time.timestamp() * 1000
 
@@ -58,10 +55,7 @@ def activities_from_pubnub_message(
         activity_dict["deviceType"] = "lock"
         activity_dict["info"] = info
         calling_user_id = message.get("callingUserID")
-        # Only accept a UserID if we have a date/time
-        # as otherwise it is a duplicate of the previous
-        # activity
-        if accept_user and calling_user_id:
+        if calling_user_id:
             activity_dict["callingUser"] = {"UserID": calling_user_id}
         if "remoteEvent" in message:
             activity_dict["info"]["remote"] = True


### PR DESCRIPTION
This reverts commit 47a9d04a2097b5ad16bf163f758be942b890c38f.

This should no longer be needed after https://github.com/bdraco/yalexs/pull/57