### PR TITLE
Handle late auth failure when switching brands (Yale Home)

### DIFF
--- a/tests/test_api_async.py
+++ b/tests/test_api_async.py
@@ -1036,9 +1036,9 @@ class TestApiAsync(aiounittest.AsyncTestCase):
 
         ERROR_MAP = {
             560: "The operation failed with error code 560: 560.",
-            422: "The operation failed because the bridge (connect) is offline.",
-            423: "The operation failed because the bridge (connect) is in use.",
-            408: "The operation timed out because the bridge (connect) failed to respond.",
+            422: "The operation failed because the bridge (connect) is offline: 422",
+            423: "The operation failed because the bridge (connect) is in use: 423",
+            408: "The operation timed out because the bridge (connect) failed to respond: 408",
         }
 
         for status_code in ERROR_MAP:

--- a/yalexs/api_async.py
+++ b/yalexs/api_async.py
@@ -4,7 +4,12 @@ import asyncio
 from http import HTTPStatus
 import logging
 
-from aiohttp import ClientResponseError, ClientSession, ServerDisconnectedError
+from aiohttp import (
+    ClientResponse,
+    ClientResponseError,
+    ClientSession,
+    ServerDisconnectedError,
+)
 
 from .api_common import (
     API_LOCK_ASYNC_URL,
@@ -333,7 +338,8 @@ class ApiAsync(ApiCommon):
         return response
 
 
-def _raise_response_exceptions(response):
+def _raise_response_exceptions(response: ClientResponse) -> None:
+    """Raise exceptions for known error codes."""
     try:
         response.raise_for_status()
     except ClientResponseError as err:

--- a/yalexs/api_async.py
+++ b/yalexs/api_async.py
@@ -1,10 +1,11 @@
 """Api calls for sync."""
 
 import asyncio
+from http import HTTPStatus
 import logging
 
 from aiohttp import ClientResponseError, ClientSession, ServerDisconnectedError
-from http import HTTPStatus
+
 from .api_common import (
     API_LOCK_ASYNC_URL,
     API_LOCK_URL,

--- a/yalexs/api_async.py
+++ b/yalexs/api_async.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 
 from aiohttp import ClientResponseError, ClientSession, ServerDisconnectedError
-
+from http import HTTPStatus
 from .api_common import (
     API_LOCK_ASYNC_URL,
     API_LOCK_URL,
@@ -336,18 +336,25 @@ def _raise_response_exceptions(response):
     try:
         response.raise_for_status()
     except ClientResponseError as err:
+        if err.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+            raise AugustApiAIOHTTPError(
+                f"Authentication failed; Verify brand is correct: {err.message}", err
+            ) from err
         if err.status == 422:
             raise AugustApiAIOHTTPError(
-                "The operation failed because the bridge (connect) is offline.",
+                f"The operation failed because the bridge (connect) is offline: {err.message}",
+                err,
             ) from err
         if err.status == 423:
             raise AugustApiAIOHTTPError(
-                "The operation failed because the bridge (connect) is in use.",
+                f"The operation failed because the bridge (connect) is in use: {err.message}",
+                err,
             ) from err
         if err.status == 408:
             raise AugustApiAIOHTTPError(
-                "The operation timed out because the bridge (connect) failed to respond.",
+                f"The operation timed out because the bridge (connect) failed to respond: {err.message}",
+                err,
             ) from err
         raise AugustApiAIOHTTPError(
-            f"The operation failed with error code {err.status}: {err.message}.",
+            f"The operation failed with error code {err.status}: {err.message}.", err
         ) from err

--- a/yalexs/exceptions.py
+++ b/yalexs/exceptions.py
@@ -1,8 +1,23 @@
 from requests.exceptions import HTTPError
 
+from aiohttp import ClientResponseError
+
+from http import HTTPStatus
+
 
 class AugustApiAIOHTTPError(Exception):
     """An yale access api error with a friendly user consumable string."""
+
+    def __init__(
+        self, message: str, aiohttp_client_response_exception: ClientResponseError
+    ) -> None:
+        """Initialize the error."""
+        super().__init__(message)
+        self.status = aiohttp_client_response_exception.status
+        self.auth_failed = self.status in (
+            HTTPStatus.UNAUTHORIZED,
+            HTTPStatus.FORBIDDEN,
+        )
 
 
 class AugustApiHTTPError(HTTPError):

--- a/yalexs/exceptions.py
+++ b/yalexs/exceptions.py
@@ -1,8 +1,7 @@
-from requests.exceptions import HTTPError
+from http import HTTPStatus
 
 from aiohttp import ClientResponseError
-
-from http import HTTPStatus
+from requests.exceptions import HTTPError
 
 
 class AugustApiAIOHTTPError(Exception):


### PR DESCRIPTION
If the user chooses the wrong brand we will get a late auth failure since the authenticator will be successful but they will not be able to access any of the locks

additional work for #59