### PR TITLE
Handle more cases of bridge offline

### DIFF
--- a/tests/test_pubnub_activity.py
+++ b/tests/test_pubnub_activity.py
@@ -398,3 +398,38 @@ class TestDetail(unittest.TestCase):
         )
         assert isinstance(activities[0], DoorbellDingActivity)
         assert "DoorbellDingActivity" in str(activities[0])
+
+
+class TestBridge(unittest.TestCase):
+    def test_update_bridge_details_from_pubnub_message(self):
+        lock = LockDetail(json.loads(load_fixture("get_lock.doorsense_init.json")))
+        self.assertEqual("A6697750D607098BAE8D6BAA11EF8063", lock.device_id)
+        self.assertEqual(LockStatus.LOCKED, lock.lock_status)
+        self.assertEqual(LockDoorStatus.DISABLED, lock.door_state)
+
+        activities = activities_from_pubnub_message(
+            lock,
+            dateutil.parser.parse("2017-12-10T05:48:30.272Z"),
+            {
+                "remoteEvent": 1,
+                "status": "unknown",
+                "result": "failed",
+                "error": {
+                    "jse_shortmsg": "",
+                    "jse_info": {},
+                    "message": "Bridge is offline",
+                    "statusCode": 422,
+                    "body": {"code": 98, "message": "Bridge is offline"},
+                    "restCode": 98,
+                    "name": "ERRNO_BRIDGE_OFFLINE",
+                    "code": "Error",
+                },
+                "info": {
+                    "lockID": "45E3635D35B9471FAF1218885816E90D",
+                    "action": "status",
+                },
+            },
+        )
+        assert isinstance(activities[0], BridgeOperationActivity)
+        assert "BridgeOperationActivity" in str(activities[0])
+        assert activities[0].action == "associated_bridge_offline"


### PR DESCRIPTION
Some more errors we don't handle

```
2023-05-17 15:17:04.873 DEBUG (MainThread) [pubnub] {'t': {'t': '16843546247478813', 'r': 21}, 'm': [{'a': '5', 'f': 0, 'i': 'pn-44660a37-5b39-4931-a00f-dba2f5424707', 'p': {'t': '16843546247478813', 'r': 43}, 'k': 'sub-c-1030e062-0ebe-11e5-a5c2-0619f8945a4f', 'c': 'XXX', 'd': {'remoteEvent': 1, 'status': 'unknown', 'result': 'failed', 'error': {'jse_shortmsg': '', 'jse_info': {}, 'message': 'Bridge is offline', 'statusCode': 422, 'body': {'code': 98, 'message': 'Bridge is offline'}, 'restCode': 98, 'name': 'ERRNO_BRIDGE_OFFLINE', 'code': 'Error'}, 'info': {'lockID': 'XXX', 'action': 'status'}}, 'b': 'XXX'}]}


2023-05-17 15:17:04.874 DEBUG (MainThread) [yalexs.pubnub_async] Recieved new messages on channel XXX for device_id: XXX with timetoken: 16843546247478813: {'remoteEvent': 1, 'status': 'unknown', 'result': 'failed', 'error': {'jse_shortmsg': '', 'jse_info': {}, 'message': 'Bridge is offline', 'statusCode': 422, 'body': {'code': 98, 'message': 'Bridge is offline'}, 'restCode': 98, 'name': 'ERRNO_BRIDGE_OFFLINE', 'code': 'Error'}, 'info': {'lockID': 'XXX', 'action': 'status'}}


2023-05-17 15:17:15.604 DEBUG (MainThread) [pubnub] {'t': {'t': '16843546355174214', 'r': 21}, 'm': [{'a': '5', 'f': 0, 'i': 'XXX', 'p': {'t': '16843546355174214', 'r': 43}, 'k': 'sub-c-1030e062-0ebe-11e5-a5c2-0619f8945a4f', 'c': 'XXX', 'd': {'remoteEvent': 1, 'status': 'unknown', 'result': 'failed', 'error': {'jse_shortmsg': '', 'jse_info': {}, 'message': 'Bridge in use', 'statusCode': 423, 'body': {'code': 97, 'message': 'Bridge in use'}, 'restCode': 97, 'name': 'ERRNO_BRIDGE_INUSE', 'code': 'Error'}, 'info': {'lockID': 'XXX', 'action': 'status'}}, 'b': 'XXX'}]}

2023-05-17 15:17:15.604 DEBUG (MainThread) [pubnub] {'t': {'t': '16843546355174214', 'r': 21}, 'm': [{'a': '5', 'f': 0, 'i': 'XXX', 'p': {'t': '16843546355174214', 'r': 43}, 'k': 'XXX', 'c': 'XXX', 'd': {'remoteEvent': 1, 'status': 'unknown', 'result': 'failed', 'error': {'jse_shortmsg': '', 'jse_info': {}, 'message': 'Bridge in use', 'statusCode': 423, 'body': {'code': 97, 'message': 'Bridge in use'}, 'restCode': 97, 'name': 'ERRNO_BRIDGE_INUSE', 'code': 'Error'}, 'info': {'lockID': 'XXX', 'action': 'status'}}, 'b': 'XXX'}]}

2023-05-17 15:17:29.815 DEBUG (MainThread) [yalexs.pubnub_async] Recieved new messages on channel XXX for device_id: XXX with timetoken: 16843546496793261: {'remoteEvent': 1, 'status': 'unknown', 'result': 'failed', 'error': {'jse_shortmsg': '', 'jse_info': {}, 'message': 'Unexpected Disconnect', 'statusCode': 560, 'body': {'code': 60, 'message': 'Unexpected Disconnect'}, 'restCode': 60, 'name': 'ERRNO_DISCONNECT', 'code': 'Error'}, 'info': {'lockID': 'XXX', 'action': 'status'}}


2023-05-17 15:17:29.813 DEBUG (MainThread) [pubnub] {'t': {'t': '16843546496793261', 'r': 21}, 'm': [{'a': '5', 'f': 0, 'i': 'XXX', 'p': {'t': '16843546496793261', 'r': 42}, 'k': 'XXX', 'c': 'XXX', 'd': {'remoteEvent': 1, 'status': 'unknown', 'result': 'failed', 'error': {'jse_shortmsg': '', 'jse_info': {}, 'message': 'Unexpected Disconnect', 'statusCode': 560, 'body': {'code': 60, 'message': 'Unexpected Disconnect'}, 'restCode': 60, 'name': 'ERRNO_DISCONNECT', 'code': 'Error'}, 'info': {'lockID': 'XXX', 'action': 'status'}}, 'b': '3XXX'}]}
```