### PR TITLE
Add end time to house activities

### DIFF
--- a/yalexs/api.py
+++ b/yalexs/api.py
@@ -95,11 +95,11 @@ class Api(ApiCommon):
             self._build_get_house_request(access_token, house_id)
         ).json()
 
-    def get_house_activities(self, access_token, house_id, limit=8):
+    def get_house_activities(self, access_token, house_id, limit=8, end_date=None):
         return _process_activity_json(
             self._dict_to_api(
                 self._build_get_house_activities_request(
-                    access_token, house_id, limit=limit
+                    access_token, house_id, limit=limit, end_date=end_date
                 )
             ).json()
         )

--- a/yalexs/api_common.py
+++ b/yalexs/api_common.py
@@ -278,15 +278,14 @@ class ApiCommon:
             "access_token": access_token,
         }
 
-    def _build_get_house_activities_request(self, access_token, house_id, limit=8):
+    def _build_get_house_activities_request(self, access_token, house_id, limit=8, end_date=None):
         return {
             "method": "get",
             "url": self.get_brand_url(
                 API_GET_HOUSE_ACTIVITIES_URL.format(house_id=house_id)
             ),
-            "version": "4.0.0",
             "access_token": access_token,
-            "params": {"limit": limit},
+            "params": {"limit": limit} | ({"endDate": int(end_date.timestamp()*1000)} if end_date != None else {}),
         }
 
     def _build_get_locks_request(self, access_token):


### PR DESCRIPTION
Activities in the house without an end time are not useful, as no more than 72 activities can be retrieved.

"version" is no longer required