### PR TITLE
Cache timestamp conversion

### DIFF
--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -6,7 +6,7 @@ from typing import Any, Union
 
 from .backports.functools import cached_property
 from .lock import LockDoorStatus, LockStatus
-from .time import parse_datetime
+from .time import epoch_to_datetime, parse_datetime
 from .users import YaleUser, get_user_info
 
 ACTION_LOCK_ONETOUCHLOCK = "onetouchlock"
@@ -142,11 +142,6 @@ SOURCE_LOG = "log"
 # If we get a lock operation activity with the same time stamp as a moving
 # activity we want to use the non-moving activity since its the completed state.
 MOVING_STATES = {LockStatus.UNLOCKING, LockStatus.LOCKING}
-
-
-def epoch_to_datetime(epoch: str | int | float) -> datetime:
-    """Convert epoch to datetime."""
-    return datetime.fromtimestamp(float(epoch) / 1000.0)
 
 
 class ActivityType(Enum):

--- a/yalexs/api.py
+++ b/yalexs/api.py
@@ -1,4 +1,5 @@
 """Api calls for sync."""
+from __future__ import annotations
 
 import json
 import logging

--- a/yalexs/api_async.py
+++ b/yalexs/api_async.py
@@ -1,9 +1,10 @@
 """Api calls for sync."""
+from __future__ import annotations
 
 import asyncio
 from http import HTTPStatus
 import logging
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any
 
 from aiohttp import (
     ClientConnectionError,
@@ -51,7 +52,7 @@ from .pin import Pin
 _LOGGER = logging.getLogger(__name__)
 
 
-def _obscure_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+def _obscure_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Obscure the payload for logging."""
     if payload is None:
         return None
@@ -138,7 +139,7 @@ class ApiAsync(ApiCommon):
             self._build_get_houses_request(access_token)
         )
 
-    async def async_get_house(self, access_token: str, house_id: str) -> Dict[str, Any]:
+    async def async_get_house(self, access_token: str, house_id: str) -> dict[str, Any]:
         response = await self._async_dict_to_api(
             self._build_get_house_request(access_token, house_id)
         )
@@ -146,7 +147,7 @@ class ApiAsync(ApiCommon):
 
     async def async_get_house_activities(
         self, access_token: str, house_id: str, limit: int = 8
-    ) -> List[ActivityTypes]:
+    ) -> list[ActivityTypes]:
         response = await self._async_dict_to_api(
             self._build_get_house_activities_request(
                 access_token, house_id, limit=limit
@@ -154,13 +155,13 @@ class ApiAsync(ApiCommon):
         )
         return _process_activity_json(await response.json())
 
-    async def async_get_locks(self, access_token: str) -> List[Lock]:
+    async def async_get_locks(self, access_token: str) -> list[Lock]:
         response = await self._async_dict_to_api(
             self._build_get_locks_request(access_token)
         )
         return _process_locks_json(await response.json())
 
-    async def async_get_operable_locks(self, access_token: str) -> List[Lock]:
+    async def async_get_operable_locks(self, access_token: str) -> list[Lock]:
         locks = await self.async_get_locks(access_token)
 
         return [lock for lock in locks if lock.is_operable]
@@ -191,7 +192,7 @@ class ApiAsync(ApiCommon):
 
     async def async_get_lock_door_status(
         self, access_token: str, lock_id: str, lock_status=False
-    ) -> Union[LockDoorStatus, Tuple[LockDoorStatus, LockStatus]]:
+    ) -> LockDoorStatus | tuple[LockDoorStatus, LockStatus]:
         response = await self._async_dict_to_api(
             self._build_get_lock_status_request(access_token, lock_id)
         )
@@ -205,7 +206,7 @@ class ApiAsync(ApiCommon):
 
         return determine_door_state(json_dict.get("doorState"))
 
-    async def async_get_pins(self, access_token: str, lock_id: str) -> List[Pin]:
+    async def async_get_pins(self, access_token: str, lock_id: str) -> list[Pin]:
         response = await self._async_dict_to_api(
             self._build_get_pins_request(access_token, lock_id)
         )
@@ -262,7 +263,7 @@ class ApiAsync(ApiCommon):
 
     async def async_lock_return_activities(
         self, access_token: str, lock_id: str
-    ) -> List[ActivityTypes]:
+    ) -> list[ActivityTypes]:
         """Execute a remote lock operation.
 
         Returns an array of one or more yalexs.activity.Activity objects
@@ -302,7 +303,7 @@ class ApiAsync(ApiCommon):
 
     async def async_unlock_return_activities(
         self, access_token: str, lock_id: str
-    ) -> List[ActivityTypes]:
+    ) -> list[ActivityTypes]:
         """Execute a remote lock operation.
 
         Returns an array of one or more yalexs.activity.Activity objects

--- a/yalexs/api_common.py
+++ b/yalexs/api_common.py
@@ -1,7 +1,9 @@
 """Api functions common between sync and async."""
+from __future__ import annotations
+
 import datetime
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from .activity import ACTION_TO_CLASS, SOURCE_LOCK_OPERATE, SOURCE_LOG, ActivityTypes
 from .const import BASE_URLS, BRANDING, Brand
@@ -64,8 +66,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _api_headers(
-    access_token: Optional[str] = None, brand: Optional[Brand] = None
-) -> Dict[str, str]:
+    access_token: str | None = None, brand: Brand | None = None
+) -> dict[str, str]:
     headers = {
         HEADER_ACCEPT_VERSION: HEADER_VALUE_ACCEPT_VERSION,
         HEADER_AUGUST_API_KEY: HEADER_VALUE_API_KEY,
@@ -83,8 +85,8 @@ def _api_headers(
 
 
 def _convert_lock_result_to_activities(
-    lock_json_dict: Dict[str, Any]
-) -> List[ActivityTypes]:
+    lock_json_dict: dict[str, Any]
+) -> list[ActivityTypes]:
     activities = []
     lock_info_json_dict = lock_json_dict.get("info", {})
     lock_id = lock_info_json_dict.get("lockID")
@@ -106,8 +108,8 @@ def _convert_lock_result_to_activities(
 
 
 def _activity_from_dict(
-    source: str, activity_dict: Dict[str, Any], debug: bool = False
-) -> Optional[ActivityTypes]:
+    source: str, activity_dict: dict[str, Any], debug: bool = False
+) -> ActivityTypes | None:
     """Convert an activity dict to and Activity object."""
     if debug:
         _LOGGER.debug("Processing activity: %s", activity_dict)
@@ -122,7 +124,7 @@ def _activity_from_dict(
 
 def _map_lock_result_to_activity(
     lock_id: str, activity_epoch: float, action_text: str
-) -> Optional[ActivityTypes]:
+) -> ActivityTypes | None:
     """Create an yale access activity from a lock result."""
     mapped_dict = {
         "dateTime": activity_epoch,
@@ -139,7 +141,7 @@ def _datetime_string_to_epoch(datetime_string: str) -> datetime.datetime:
     return parse_datetime(datetime_string).timestamp() * 1000
 
 
-def _process_activity_json(json_dict: Dict[str, Any]) -> List[ActivityTypes]:
+def _process_activity_json(json_dict: dict[str, Any]) -> list[ActivityTypes]:
     if "events" in json_dict:
         json_dict = json_dict["events"]
     debug = _LOGGER.isEnabledFor(logging.DEBUG)
@@ -150,11 +152,11 @@ def _process_activity_json(json_dict: Dict[str, Any]) -> List[ActivityTypes]:
     return activities
 
 
-def _process_doorbells_json(json_dict: Dict[str, Any]) -> List[Doorbell]:
+def _process_doorbells_json(json_dict: dict[str, Any]) -> list[Doorbell]:
     return [Doorbell(device_id, data) for device_id, data in json_dict.items()]
 
 
-def _process_locks_json(json_dict: Dict[str, Any]) -> List[Lock]:
+def _process_locks_json(json_dict: dict[str, Any]) -> list[Lock]:
     return [Lock(device_id, data) for device_id, data in json_dict.items()]
 
 
@@ -298,7 +300,7 @@ class ApiCommon:
 
     def _build_call_lock_operation_request(
         self, url_str: str, access_token: str, lock_id: str, timeout
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return {
             "method": "put",
             "url": self.get_brand_url(url_str.format(lock_id=lock_id)),

--- a/yalexs/authenticator.py
+++ b/yalexs/authenticator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 import json
 import logging

--- a/yalexs/authenticator_async.py
+++ b/yalexs/authenticator_async.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 import json
 import logging
 import os
-from typing import Optional
 
 import aiofiles
 from aiohttp import ClientError
@@ -117,7 +118,7 @@ class AuthenticatorAsync(AuthenticatorCommon):
 
         return True
 
-    async def async_refresh_access_token(self, force=False) -> Optional[Authentication]:
+    async def async_refresh_access_token(self, force=False) -> Authentication | None:
         if not self.should_refresh() and not force:
             return self._authentication
 

--- a/yalexs/authenticator_common.py
+++ b/yalexs/authenticator_common.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 import json
 import logging
-from typing import Any, Optional
+from typing import Any
 import uuid
 
 import jwt
@@ -99,8 +101,8 @@ class AuthenticatorCommon:
         login_method: str,
         username: str,
         password: str,
-        install_id: Optional[str] = None,
-        access_token_cache_file: Optional[str] = None,
+        install_id: str | None = None,
+        access_token_cache_file: str | None = None,
         access_token_renewal_threshold: timedelta = DEFAULT_RENEWAL_THRESHOLD,
     ) -> None:
         self._api = api

--- a/yalexs/exceptions.py
+++ b/yalexs/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from http import HTTPStatus
 
 from aiohttp import ClientError, ClientResponseError

--- a/yalexs/lock.py
+++ b/yalexs/lock.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 from enum import Enum
-from typing import List, Optional
 
 from .backports.functools import cached_property
 from .bridge import BridgeDetail, BridgeStatus
@@ -210,25 +209,25 @@ class LockDetail(DeviceDetail):
         return self._data.get("OfflineKeys", {})
 
     @cached_property
-    def loaded_offline_keys(self) -> List[dict]:
+    def loaded_offline_keys(self) -> list[dict]:
         return self.offline_keys.get("loaded", [])
 
     @cached_property
-    def offline_key(self) -> Optional[str]:
+    def offline_key(self) -> str | None:
         loaded_offline_keys = self.loaded_offline_keys
         if loaded_offline_keys and "key" in loaded_offline_keys[0]:
             return loaded_offline_keys[0]["key"]
         return None
 
     @cached_property
-    def offline_slot(self) -> Optional[int]:
+    def offline_slot(self) -> int | None:
         loaded_offline_keys = self.loaded_offline_keys
         if loaded_offline_keys and "slot" in loaded_offline_keys[0]:
             return loaded_offline_keys[0]["slot"]
         return None
 
     @cached_property
-    def mac_address(self) -> Optional[str]:
+    def mac_address(self) -> str | None:
         mac = self._data.get("macAddress")
         return mac.upper() if mac else None
 

--- a/yalexs/pin.py
+++ b/yalexs/pin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .time import parse_datetime
 
 

--- a/yalexs/pubnub_activity.py
+++ b/yalexs/pubnub_activity.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from .activity import (
     ACTION_BRIDGE_OFFLINE,
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def activities_from_pubnub_message(
-    device: Device, date_time: datetime, message: Dict[str, Any]
+    device: Device, date_time: datetime, message: dict[str, Any]
 ) -> list[ActivityTypes]:
     """Create activities from pubnub."""
     activities: list[ActivityTypes] = []

--- a/yalexs/time.py
+++ b/yalexs/time.py
@@ -1,7 +1,14 @@
 import datetime
+from functools import lru_cache
 
 import ciso8601
 import dateutil.parser
+
+
+@lru_cache(maxsize=512)
+def epoch_to_datetime(epoch: str | int | float) -> datetime.datetime:
+    """Convert epoch to datetime."""
+    return datetime.datetime.fromtimestamp(float(epoch) / 1000.0)
 
 
 def parse_datetime(datetime_string: str) -> datetime.datetime:

--- a/yalexs/time.py
+++ b/yalexs/time.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from functools import lru_cache
 

--- a/yalexs/users.py
+++ b/yalexs/users.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Optional
+from __future__ import annotations
+
+from typing import Any
 
 from .backports.functools import cached_property
 
@@ -8,36 +10,36 @@ USER_CACHE = {}
 class YaleUser:
     """Represent a yale access user."""
 
-    def __init__(self, uuid: str, data: Dict[str, Any]) -> None:
+    def __init__(self, uuid: str, data: dict[str, Any]) -> None:
         """Initialize the YaleUser."""
         self._uuid = uuid
         self._data = data
 
     @cached_property
-    def thumbnail_url(self) -> Optional[str]:
+    def thumbnail_url(self) -> str | None:
         return self._data.get("imageInfo", {}).get("thumbnail", {}).get("secure_url")
 
     @cached_property
-    def image_url(self) -> Optional[str]:
+    def image_url(self) -> str | None:
         return self._data.get("imageInfo", {}).get("original", {}).get("secure_url")
 
     @cached_property
-    def first_name(self) -> Optional[str]:
+    def first_name(self) -> str | None:
         return self._data.get("FirstName")
 
     @cached_property
-    def last_name(self) -> Optional[str]:
+    def last_name(self) -> str | None:
         return self._data.get("LastName")
 
     @cached_property
-    def user_type(self) -> Optional[str]:
+    def user_type(self) -> str | None:
         return self._data.get("UserType")
 
 
-def get_user_info(uuid: str) -> Optional[YaleUser]:
+def get_user_info(uuid: str) -> YaleUser | None:
     return USER_CACHE.get(uuid)
 
 
-def cache_user_info(uuid: str, data: Dict[str, Any]) -> None:
+def cache_user_info(uuid: str, data: dict[str, Any]) -> None:
     if uuid not in USER_CACHE:
         USER_CACHE[uuid] = YaleUser(uuid, data)

--- a/yalexs/util.py
+++ b/yalexs/util.py
@@ -32,8 +32,7 @@ def get_latest_activity(
     if not activity2:
         return activity1
     if (
-        activity2.activity_start_time > activity1.activity_start_time
-        or activity1.activity_start_time == activity2.activity_start_time
+        activity1.activity_start_time <= activity2.activity_start_time
         and ACTIVITY_ACTION_STATES.get(activity2.action) not in MOVING_STATES
     ):
         return activity2


### PR DESCRIPTION
We end up converting the same data over and over since we get 72 new activities every time we poll the api, and we likely have seen 71 of them before

- removes some duplicate code and updates some more typing
 