### PR TITLE
Add more activity types

### DIFF
--- a/tests/fixtures/rf_unlock_activity_v4.json
+++ b/tests/fixtures/rf_unlock_activity_v4.json
@@ -1,0 +1,14 @@
+{
+	"id": "b4e50f6c-730a-4ae1-991e-e5231d727c11",
+	"timestamp": 1665388800273,
+	"icon": "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/rf_unlock@3x.png",
+	"action": "rf_unlock",
+	"deviceID": "102A6A4F31584849971D11807272E7A8",
+	"deviceType": "lock",
+	"user": {
+		"UserID": "83f02a1d-c08a-4c3d-9c30-3b66e185c7bd",
+		"FirstName": "89",
+		"LastName": "House"
+	},
+	"title": "<b>89 House</b> unlocked <b>Gate</b> rf_unlock"
+}

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -142,8 +142,8 @@ class TestActivity(unittest.TestCase):
         assert auto_unlock_activity.operated_by == "My Name"
         assert auto_unlock_activity.operated_remote is False
         assert auto_unlock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert auto_unlock_activity.operated_manual is False
+        assert auto_unlock_activity.operated_tag is False
 
     def test_bluetooth_lock_activity(self):
         bluetooth_lock_activity = LockOperationActivity(
@@ -152,8 +152,8 @@ class TestActivity(unittest.TestCase):
         assert bluetooth_lock_activity.operated_by == "I have a picture"
         assert bluetooth_lock_activity.operated_remote is False
         assert bluetooth_lock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert bluetooth_lock_activity.operated_manual is False
+        assert bluetooth_lock_activity.operated_tag is False
         assert bluetooth_lock_activity.operator_image_url == "https://image.url"
         assert bluetooth_lock_activity.operator_thumbnail_url == "https://thumbnail.url"
 
@@ -164,8 +164,8 @@ class TestActivity(unittest.TestCase):
         assert keypad_lock_activity.operated_by == "My Name"
         assert keypad_lock_activity.operated_remote is False
         assert keypad_lock_activity.operated_keypad is True
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert keypad_lock_activity.operated_manual is False
+        assert keypad_lock_activity.operated_tag is False
         assert keypad_lock_activity.operator_image_url is None
         assert keypad_lock_activity.operator_thumbnail_url is None
 
@@ -176,8 +176,8 @@ class TestActivity(unittest.TestCase):
         assert auto_lock_activity.operated_by == "Auto Lock"
         assert auto_lock_activity.operated_remote is False
         assert auto_lock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert auto_lock_activity.operated_manual is False
+        assert auto_lock_activity.operated_tag is False
         assert (
             auto_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/auto_lock@3x.png"
@@ -194,8 +194,8 @@ class TestActivity(unittest.TestCase):
         assert keypad_lock_activity.operated_by == "Sample Person"
         assert keypad_lock_activity.operated_remote is False
         assert keypad_lock_activity.operated_keypad is True
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert keypad_lock_activity.operated_manual is False
+        assert keypad_lock_activity.operated_tag is False
         assert (
             keypad_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/pin_unlock@3x.png"
@@ -212,8 +212,8 @@ class TestActivity(unittest.TestCase):
         assert keypad_lock_activity.operated_by == "Zip Zoo"
         assert keypad_lock_activity.operated_remote is False
         assert keypad_lock_activity.operated_keypad is True
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert keypad_lock_activity.operated_manual is False
+        assert keypad_lock_activity.operated_tag is False
         assert (
             keypad_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/user/abc.jpg"
@@ -230,8 +230,8 @@ class TestActivity(unittest.TestCase):
         assert remote_lock_activity.operated_by == "My Name"
         assert remote_lock_activity.operated_remote is True
         assert remote_lock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert remote_lock_activity.operated_manual is False
+        assert remote_lock_activity.operated_tag is False
 
     def test_remote_lock_activity_v4(self):
         remote_lock_activity = LockOperationActivity(
@@ -240,8 +240,8 @@ class TestActivity(unittest.TestCase):
         assert remote_lock_activity.operated_by == "89 House"
         assert remote_lock_activity.operated_remote is True
         assert remote_lock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert remote_lock_activity.operated_manual is False
+        assert remote_lock_activity.operated_tag is False
         assert (
             remote_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/remote_lock@3x.png"
@@ -259,8 +259,8 @@ class TestActivity(unittest.TestCase):
         assert remote_unlock_activity.operated_by == "89 House"
         assert remote_unlock_activity.operated_remote is True
         assert remote_unlock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert remote_unlock_activity.operated_manual is False
+        assert remote_unlock_activity.operated_tag is False
         assert (
             remote_unlock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/remote_unlock@3x.png"
@@ -278,8 +278,8 @@ class TestActivity(unittest.TestCase):
         assert remote_unlock_activity.operated_by == "Zipper Zoomer"
         assert remote_unlock_activity.operated_remote is True
         assert remote_unlock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is False
+        assert remote_unlock_activity.operated_manual is False
+        assert remote_unlock_activity.operated_tag is False
         assert (
             remote_unlock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/user/a45daa08-f4b0-4251-aacd-7bf5475851e5.jpg"
@@ -314,8 +314,8 @@ class TestActivity(unittest.TestCase):
         assert manual_unlock_activity.operated_by == "Manual Unlock"
         assert manual_unlock_activity.operated_remote is False
         assert manual_unlock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is True
-        assert manual_lock_activity.operated_tag is False
+        assert manual_unlock_activity.operated_manual is True
+        assert manual_unlock_activity.operated_tag is False
         assert (
             manual_unlock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/manual_unlock@3x.png"
@@ -326,20 +326,20 @@ class TestActivity(unittest.TestCase):
         )
 
     def test_rf_unlock_activity_v4(self):
-        manual_unlock_activity = LockOperationActivity(
+        rf_unlock_activity = LockOperationActivity(
             SOURCE_LOG, json.loads(load_fixture("rf_unlock_activity.json"))
         )
-        assert manual_unlock_activity.operated_by == "89 House"
-        assert manual_unlock_activity.operated_remote is False
-        assert manual_unlock_activity.operated_keypad is False
-        assert manual_lock_activity.operated_manual is False
-        assert manual_lock_activity.operated_tag is True
+        assert rf_unlock_activity.operated_by == "89 House"
+        assert rf_unlock_activity.operated_remote is False
+        assert rf_unlock_activity.operated_keypad is False
+        assert rf_unlock_activity.operated_manual is False
+        assert rf_unlock_activity.operated_tag is True
         assert (
-            manual_unlock_activity.operator_image_url
+            rf_unlock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/rf_unlock@3x.png"
         )
         assert (
-            manual_unlock_activity.operator_thumbnail_url
+            rf_unlock_activity.operator_thumbnail_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/rf_unlock@3x.png"
         )
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -142,6 +142,8 @@ class TestActivity(unittest.TestCase):
         assert auto_unlock_activity.operated_by == "My Name"
         assert auto_unlock_activity.operated_remote is False
         assert auto_unlock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
 
     def test_bluetooth_lock_activity(self):
         bluetooth_lock_activity = LockOperationActivity(
@@ -150,6 +152,8 @@ class TestActivity(unittest.TestCase):
         assert bluetooth_lock_activity.operated_by == "I have a picture"
         assert bluetooth_lock_activity.operated_remote is False
         assert bluetooth_lock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
         assert bluetooth_lock_activity.operator_image_url == "https://image.url"
         assert bluetooth_lock_activity.operator_thumbnail_url == "https://thumbnail.url"
 
@@ -160,6 +164,8 @@ class TestActivity(unittest.TestCase):
         assert keypad_lock_activity.operated_by == "My Name"
         assert keypad_lock_activity.operated_remote is False
         assert keypad_lock_activity.operated_keypad is True
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
         assert keypad_lock_activity.operator_image_url is None
         assert keypad_lock_activity.operator_thumbnail_url is None
 
@@ -170,6 +176,8 @@ class TestActivity(unittest.TestCase):
         assert auto_lock_activity.operated_by == "Auto Lock"
         assert auto_lock_activity.operated_remote is False
         assert auto_lock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
         assert (
             auto_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/auto_lock@3x.png"
@@ -186,6 +194,8 @@ class TestActivity(unittest.TestCase):
         assert keypad_lock_activity.operated_by == "Sample Person"
         assert keypad_lock_activity.operated_remote is False
         assert keypad_lock_activity.operated_keypad is True
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
         assert (
             keypad_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/pin_unlock@3x.png"
@@ -202,6 +212,8 @@ class TestActivity(unittest.TestCase):
         assert keypad_lock_activity.operated_by == "Zip Zoo"
         assert keypad_lock_activity.operated_remote is False
         assert keypad_lock_activity.operated_keypad is True
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
         assert (
             keypad_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/user/abc.jpg"
@@ -218,6 +230,8 @@ class TestActivity(unittest.TestCase):
         assert remote_lock_activity.operated_by == "My Name"
         assert remote_lock_activity.operated_remote is True
         assert remote_lock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
 
     def test_remote_lock_activity_v4(self):
         remote_lock_activity = LockOperationActivity(
@@ -226,6 +240,8 @@ class TestActivity(unittest.TestCase):
         assert remote_lock_activity.operated_by == "89 House"
         assert remote_lock_activity.operated_remote is True
         assert remote_lock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
         assert (
             remote_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/remote_lock@3x.png"
@@ -243,6 +259,8 @@ class TestActivity(unittest.TestCase):
         assert remote_unlock_activity.operated_by == "89 House"
         assert remote_unlock_activity.operated_remote is True
         assert remote_unlock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
         assert (
             remote_unlock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/remote_unlock@3x.png"
@@ -260,6 +278,8 @@ class TestActivity(unittest.TestCase):
         assert remote_unlock_activity.operated_by == "Zipper Zoomer"
         assert remote_unlock_activity.operated_remote is True
         assert remote_unlock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is False
         assert (
             remote_unlock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/user/a45daa08-f4b0-4251-aacd-7bf5475851e5.jpg"
@@ -276,6 +296,8 @@ class TestActivity(unittest.TestCase):
         assert manual_lock_activity.operated_by == "Manual Lock"
         assert manual_lock_activity.operated_remote is False
         assert manual_lock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is True
+        assert manual_lock_activity.operated_tag is False
         assert (
             manual_lock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/manual_lock@3x.png"
@@ -292,6 +314,8 @@ class TestActivity(unittest.TestCase):
         assert manual_unlock_activity.operated_by == "Manual Unlock"
         assert manual_unlock_activity.operated_remote is False
         assert manual_unlock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is True
+        assert manual_lock_activity.operated_tag is False
         assert (
             manual_unlock_activity.operator_image_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/manual_unlock@3x.png"
@@ -299,6 +323,24 @@ class TestActivity(unittest.TestCase):
         assert (
             manual_unlock_activity.operator_thumbnail_url
             == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/manual_unlock@3x.png"
+        )
+
+    def test_rf_unlock_activity_v4(self):
+        manual_unlock_activity = LockOperationActivity(
+            SOURCE_LOG, json.loads(load_fixture("rf_unlock_activity.json"))
+        )
+        assert manual_unlock_activity.operated_by == "89 House"
+        assert manual_unlock_activity.operated_remote is False
+        assert manual_unlock_activity.operated_keypad is False
+        assert manual_lock_activity.operated_manual is False
+        assert manual_lock_activity.operated_tag is True
+        assert (
+            manual_unlock_activity.operator_image_url
+            == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/rf_unlock@3x.png"
+        )
+        assert (
+            manual_unlock_activity.operator_thumbnail_url
+            == "https://d33mytkkohwnk6.cloudfront.net/app/ActivityFeedIcons/rf_unlock@3x.png"
         )
 
     def test_lock_activity(self):

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -327,7 +327,7 @@ class TestActivity(unittest.TestCase):
 
     def test_rf_unlock_activity_v4(self):
         rf_unlock_activity = LockOperationActivity(
-            SOURCE_LOG, json.loads(load_fixture("rf_unlock_activity.json"))
+            SOURCE_LOG, json.loads(load_fixture("rf_unlock_activity_v4.json"))
         )
         assert rf_unlock_activity.operated_by == "89 House"
         assert rf_unlock_activity.operated_remote is False

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -453,15 +453,11 @@ class LockOperationActivity(Activity):
         """Operation used rfid tag."""
         return self._info.get("tag", self.action in TAG_ACTIONS)
 
-    
     @cached_property
     def operated_autorelock(self):
         """Operation done by automatic relock."""
         return self.user_id == "automaticrelock" or self.action in AUTO_RELOCK_ACTIONS
 
-
-    
-    
     @cached_property
     def operator_image_url(self):
         """URL to the image of the lock operator."""

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -110,6 +110,17 @@ REMOTE_ACTIONS = {
 }
 AUTO_RELOCK_ACTIONS = {ACTION_LOCK_AUTO_LOCK}
 
+TAG_ACTIONS = {
+    ACTION_RF_SECURE,
+    ACTION_RF_LOCK,
+    ACTION_RF_UNLOCK,
+}
+
+MANUAL_ACTIONS = {
+    ACTION_LOCK_MANUAL_LOCK,
+    ACTION_LOCK_MANUAL_UNLOCK,
+}
+
 ACTIVITY_ACTION_STATES = {
     ACTION_RF_SECURE: LockStatus.LOCKED,
     ACTION_RF_LOCK: LockStatus.LOCKED,
@@ -396,6 +407,8 @@ class LockOperationActivity(Activity):
             f"operated_by={self.operated_by} "
             f"operated_remote={self.operated_remote} "
             f"operated_keypad={self.operated_keypad} "
+            f"operated_tag={self.operated_tag} "
+            f"operated_manual={self.operated_manual} "
             f"operated_autorelock={self.operated_autorelock} "
             f"operator_image_url={self.operator_image_url} "
             f"operator_thumbnail_url={self.operator_thumbnail_url}>"
@@ -431,10 +444,24 @@ class LockOperationActivity(Activity):
         return self._info.get("keypad", self.action in KEYPAD_ACTIONS)
 
     @cached_property
+    def operated_manual(self):
+        """Operation done manually using the knob."""
+        return self._info.get("manual", self.action in MANUAL_ACTIONS)
+
+    @cached_property
+    def operated_tag(self):
+        """Operation used rfid tag."""
+        return self._info.get("tag", self.action in TAG_ACTIONS)
+
+    
+    @cached_property
     def operated_autorelock(self):
         """Operation done by automatic relock."""
         return self.user_id == "automaticrelock" or self.action in AUTO_RELOCK_ACTIONS
 
+
+    
+    
     @cached_property
     def operator_image_url(self):
         """URL to the image of the lock operator."""


### PR DESCRIPTION
This adds support for manual lock/unlock and unlock using rfid-tags:

Example activities:

*Manual lock*

```
<LockOperationActivity action=manual_lock activity_type=ActivityType.LOCK_OPERATION activity_start_time=2023-09-20 22:28:17 device_name=None operated_by=Manual Lock operated_remote=False operated_keypad=False operated_tag=False operated_manual=True operated_autorelock=False operator_image_url=https://d3osa7xy9vsc0q.cloudfront.net/app/ActivityFeedIcons/manual_lock@3x.png operator_thumbnail_url=https://d3osa7xy9vsc0q.cloudfront.net/app/ActivityFeedIcons/manual_lock@3x.png>
```
Notice `operated_manual=True`

*Manual unlock*
```
<LockOperationActivity action=manual_unlock activity_type=ActivityType.LOCK_OPERATION activity_start_time=2023-09-20 22:27:55 device_name=None operated_by=Manual Unlock operated_remote=False operated_keypad=False operated_tag=False operated_manual=True operated_autorelock=False operator_image_url=https://d3osa7xy9vsc0q.cloudfront.net/app/ActivityFeedIcons/manual_unlock@3x.png operator_thumbnail_url=https://d3osa7xy9vsc0q.cloudfront.net/app/ActivityFeedIcons/manual_unlock@3x.png>
```
Notice `operated_manual=True`

*Tag unlock*
```
<LockOperationActivity action=rf_unlock activity_type=ActivityType.LOCK_OPERATION activity_start_time=2023-09-20 22:28:09 device_name=None operated_by=My Name operated_remote=False operated_keypad=False operated_tag=True operated_manual=False operated_autorelock=False operator_image_url=https://d3osa7xy9vsc0q.cloudfront.net/app/ActivityFeedIcons/rf_unlock@3x.png operator_thumbnail_url=https://d3osa7xy9vsc0q.cloudfront.net/app/ActivityFeedIcons/rf_unlock@3x.png>
```
Notice `operated_tag=True`

