### PR TITLE
Camera content-token raise error on expiry

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -21,11 +21,8 @@ disable=
   locally-disabled,
   duplicate-code,
   cyclic-import,
-  abstract-class-little-used,
-  abstract-class-not-used,
   unused-argument,
   global-statement,
-  redefined-variable-type,
   too-many-arguments,
   too-many-branches,
   too-many-instance-attributes,
@@ -37,9 +34,8 @@ disable=
   too-few-public-methods,
   abstract-method,
   missing-docstring,
-  no-self-use,
   unspecified-encoding,
   consider-using-f-string
 
 [EXCEPTIONS]
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -258,6 +258,7 @@ class BaseDoorbellMotionActivity(Activity):
         """Initialize doorbell motion activity."""
         super().__init__(source, activity_type, data)
         self._image: dict[str, Any] | None = data.get("info", {}).get("image")
+        self._content_token = data.get("doorbell", {}).get("contentToken")
 
     def __repr__(self):
         return (
@@ -265,6 +266,7 @@ class BaseDoorbellMotionActivity(Activity):
             f"activity_start_time={self.activity_start_time} "
             f"device_name={self.device_name}"
             f"image_url={self.image_url}>"
+            f"content_token={self.content_token}"
         )
 
     @cached_property
@@ -274,6 +276,11 @@ class BaseDoorbellMotionActivity(Activity):
         return (None if image is None else image.get("secure_url")) or self._data.get(
             "attachment"
         )
+
+    @cached_property
+    def content_token(self):
+        """Return the contentToken for the image URL"""
+        return self._content_token or ""
 
     @cached_property
     def image_created_at_datetime(self):
@@ -308,7 +315,16 @@ class DoorbellBaseActionActivity(Activity):
     @cached_property
     def image_url(self):
         """Return the image URL of the activity."""
-        return self._info.get("image") or self._info.get("attachment")
+        return (
+            self._info.get("image")
+            or self._info.get("attachment")
+            or self._data.get("attachment")
+        )
+
+    @cached_property
+    def content_token(self):
+        """Return contentToken for image URL"""
+        return self._data.get("doorbell", {}).get("contentToken")
 
     @cached_property
     def activity_start_time(self):

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -315,16 +315,7 @@ class DoorbellBaseActionActivity(Activity):
     @cached_property
     def image_url(self):
         """Return the image URL of the activity."""
-        return (
-            self._info.get("image")
-            or self._info.get("attachment")
-            or self._data.get("attachment")
-        )
-
-    @cached_property
-    def content_token(self):
-        """Return contentToken for image URL"""
-        return self._data.get("doorbell", {}).get("contentToken")
+        return self._info.get("image") or self._info.get("attachment")
 
     @cached_property
     def activity_start_time(self):

--- a/yalexs/doorbell.py
+++ b/yalexs/doorbell.py
@@ -7,6 +7,8 @@ from typing import Any
 from aiohttp import ClientSession
 import requests
 
+from yalexs.exceptions import TokenExpiredException
+
 from .backports.functools import cached_property
 from .device import Device, DeviceDetail
 from .time import parse_datetime
@@ -174,7 +176,7 @@ class DoorbellDetail(DeviceDetail):
             _LOGGER.error(
                 "snapshot get error %s, may need new content token", response.status
             )
-            raise ValueError(response.status)
+            raise TokenExpiredException
         return await response.read()
 
     def get_doorbell_image(self, timeout=10) -> bytes:

--- a/yalexs/doorbell.py
+++ b/yalexs/doorbell.py
@@ -7,7 +7,7 @@ from typing import Any
 from aiohttp import ClientSession
 import requests
 
-from yalexs.exceptions import TokenExpiredException
+from yalexs.exceptions import ContentTokenExpired
 
 from .backports.functools import cached_property
 from .device import Device, DeviceDetail
@@ -172,11 +172,11 @@ class DoorbellDetail(DeviceDetail):
             timeout=timeout,
             headers={"Authorization": self._content_token or ""},
         )
-        if response.status >= 400:
-            _LOGGER.error(
+        if response.status == 401:
+            _LOGGER.debug(
                 "snapshot get error %s, may need new content token", response.status
             )
-            raise TokenExpiredException
+            raise ContentTokenExpired
         return await response.read()
 
     def get_doorbell_image(self, timeout=10) -> bytes:

--- a/yalexs/exceptions.py
+++ b/yalexs/exceptions.py
@@ -24,3 +24,6 @@ class AugustApiAIOHTTPError(Exception):
 
 class AugustApiHTTPError(HTTPError):
     """An yale access api error with a friendly user consumable string."""
+
+class TokenExpiredException(Exception):
+    """Token required for accessing this resource is not valid."""

--- a/yalexs/exceptions.py
+++ b/yalexs/exceptions.py
@@ -25,5 +25,6 @@ class AugustApiAIOHTTPError(Exception):
 class AugustApiHTTPError(HTTPError):
     """An yale access api error with a friendly user consumable string."""
 
+
 class TokenExpiredException(Exception):
     """Token required for accessing this resource is not valid."""

--- a/yalexs/exceptions.py
+++ b/yalexs/exceptions.py
@@ -26,5 +26,5 @@ class AugustApiHTTPError(HTTPError):
     """An yale access api error with a friendly user consumable string."""
 
 
-class TokenExpiredException(Exception):
+class ContentTokenExpired(Exception):
     """Token required for accessing this resource is not valid."""

--- a/yalexs/util.py
+++ b/yalexs/util.py
@@ -99,6 +99,9 @@ def update_doorbell_image_from_activity(doorbell_detail, activity):
             doorbell_detail.image_created_at_datetime = (
                 activity.image_created_at_datetime
             )
+            doorbell_detail.content_token = (
+                activity.content_token or doorbell_detail.content_token
+            )
         else:
             return False
     else:


### PR DESCRIPTION
So if we get an http error trying to get the snapshot image, we raise that to the caller/integration so we can from there get a new content-token from the yale home server and do a retry.

So this will require a change in the august integration as well once merged. 
 