### PR TITLE
fix: tests with aiohttp >= 3.10.0

### DIFF
--- a/tests/test_api_async.py
+++ b/tests/test_api_async.py
@@ -1187,7 +1187,7 @@ class TestApiAsync(aiounittest.AsyncTestCase):
         )
         assert last_args["json"] == {"code": "123456", "email": "emailaddress"}
 
-    def test__raise_response_exceptions(self):
+    async def test__raise_response_exceptions(self):
         loop = mock.Mock()
         request_info = mock.Mock()
         request_info.status.return_value = 428


### PR DESCRIPTION
aiohttp 3.10.0 removed the ability to create `aiohttp.ClientSession` instances without a running event loop (see
https://github.com/aio-libs/aiohttp/pull/8583), but one of yalexs's tests relied on that.