### PR TITLE
fix: timestamp division for datetime generation in tests

### DIFF
--- a/tests/test_pubnub_activity.py
+++ b/tests/test_pubnub_activity.py
@@ -317,7 +317,7 @@ class TestLockDetail(unittest.TestCase):
 
         activities = activities_from_pubnub_message(
             lock,
-            datetime.datetime.fromtimestamp(16844292526891571 / 1000000),
+            datetime.datetime.fromtimestamp(16844292526891571 / 10_000_000),
             {
                 "status": "unlatched",
                 "callingUserID": "manualunlatch",
@@ -334,7 +334,7 @@ class TestLockDetail(unittest.TestCase):
 
         activities = activities_from_pubnub_message(
             lock,
-            datetime.datetime.fromtimestamp(16844292526891571 / 1000000),
+            datetime.datetime.fromtimestamp(16844292526891571 / 10_000_000),
             {
                 "status": "unlocked",
                 "callingUserID": "manualunlock",
@@ -351,7 +351,7 @@ class TestLockDetail(unittest.TestCase):
 
         activities = activities_from_pubnub_message(
             lock,
-            datetime.datetime.fromtimestamp(16844299539729015 / 1000000),
+            datetime.datetime.fromtimestamp(16844299539729015 / 10_000_000),
             {
                 "status": "locked",
                 "callingUserID": "manuallock",


### PR DESCRIPTION
This commit corrects the method of converting timestamps to datetime objects in the tests for `tests/test_pubnub_activity.py`. Previously, timestamps were divided by 1_000_000, which generated dates in the year 2503, causing an overflow error on i386 architectures. The division factor has been adjusted to 10_000_000 to produce more realistic dates in 2023. Additionally, underscores are used as thousand separators to enhance readability.