### PR TITLE
fix: add default first & last names for pin_* actions

### DIFF
--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -128,6 +128,8 @@ ACTIVITY_TO_FIRST_LAST_NAME = {
     ACTION_LOCK_MANUAL_UNLOCK: ("Manual", "Unlock"),
     ACTION_LOCK_FINGER_LOCK: ("Fingerprint", "Lock"),
     ACTION_LOCK_FINGER_UNLOCK: ("Fingerprint", "Unlock"),
+    ACTION_LOCK_PIN_UNLATCH: ("Pin", "Unlatch"),
+    ACTION_LOCK_PIN_UNLOCK: ("Pin", "Unlock"),
 }
 
 


### PR DESCRIPTION
This adds `ACTION_LOCK_PIN_UNLATCH` and `ACTION_LOCK_PIN_UNLOCK` to the `ACTIVITY_TO_FIRST_LAST_NAME` map for the rare cases where the API doesn't return a user, and we need a fallback.