### PR TITLE
fix: reduce excessive activity API calls for August and Yale locks

### DIFF
--- a/tests/test_pubnub_activity.py
+++ b/tests/test_pubnub_activity.py
@@ -178,7 +178,7 @@ class TestLockDetail(unittest.TestCase):
         assert isinstance(activities[0], LockOperationActivity)
         assert "LockOperationActivity" in str(activities[0])
         assert activities[0].activity_start_time == dateutil.parser.parse(
-            "2021-03-20T18:19:06.372Z"
+            "2021-03-20T18:19:06.374Z"
         ).astimezone(tz=tzlocal()).replace(tzinfo=None)
         assert activities[0].action == "unlock"
 

--- a/tests/test_pubnub_activity.py
+++ b/tests/test_pubnub_activity.py
@@ -147,7 +147,7 @@ class TestLockDetail(unittest.TestCase):
         )
         assert isinstance(activities[0], LockOperationActivity)
         assert activities[0].activity_start_time == dateutil.parser.parse(
-            "2021-03-20T18:19:06.372Z"
+            "2021-03-20T18:19:06.374Z"
         ).astimezone(tz=tzlocal()).replace(tzinfo=None)
         assert "LockOperationActivity" in str(activities[0])
         assert activities[0].action == "jammed"

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -341,7 +341,15 @@ class Activity:
     @cached_property
     def is_status(self) -> bool:
         """Return if the activity is a status update."""
-        return not self._info or self.action == "status"
+        # If action is explicitly "status", it's a status update
+        if self.action == "status":
+            return True
+        # If there's a calling user, it's likely a real event (e.g., Bluetooth unlock)
+        # even if info is empty
+        if self.calling_user:
+            return False
+        # Otherwise, empty info means status update
+        return not self._info
 
 
 class BaseDoorbellMotionActivity(Activity):

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -353,8 +353,8 @@ class Activity:
         user_id = self.calling_user.get("UserID", "")
         if user_id and user_id.startswith("manual"):
             return False
-        # Empty info typically means status update
-        return not self._info
+        # Empty info typically means status update (except for WebSocket activities)
+        return not self._info and self.source != SOURCE_WEBSOCKET
 
 
 class BaseDoorbellMotionActivity(Activity):

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -339,6 +339,11 @@ class Activity:
         return self._data.get("deviceType")
 
     @cached_property
+    def calling_user(self) -> dict[str, Any]:
+        """Return the calling user."""
+        return self._data.get("callingUser", self._data.get("user", {}))
+
+    @cached_property
     def is_status(self) -> bool:
         """Return if the activity is a status update."""
         # If action is explicitly "status", it's a status update
@@ -539,11 +544,6 @@ class LockOperationActivity(Activity):
     def yale_user(self) -> YaleUser | None:
         """Return the Yale user."""
         return get_user_info(self.user_id)
-
-    @cached_property
-    def calling_user(self) -> dict[str, Any]:
-        """Return the the calling user."""
-        return self._data.get("callingUser", self._data.get("user", {}))
 
     @cached_property
     def user_id(self) -> str | None:

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -338,6 +338,11 @@ class Activity:
         """Return the type of the device."""
         return self._data.get("deviceType")
 
+    @cached_property
+    def is_status(self) -> bool:
+        """Return if the activity is a status update."""
+        return not self._info or self.action == "status"
+
 
 class BaseDoorbellMotionActivity(Activity):
     """Base class for doorbell motion activities."""

--- a/yalexs/activity.py
+++ b/yalexs/activity.py
@@ -349,11 +349,11 @@ class Activity:
         # If action is explicitly "status", it's a status update
         if self.action == "status":
             return True
-        # If there's a calling user, it's likely a real event (e.g., Bluetooth unlock)
-        # even if info is empty
-        if self.calling_user:
+        # If there's a manual operation (Bluetooth lock/unlock), it's NOT a status update
+        user_id = self.calling_user.get("UserID", "")
+        if user_id and user_id.startswith("manual"):
             return False
-        # Otherwise, empty info means status update
+        # Empty info typically means status update
         return not self._info
 
 

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -300,6 +300,12 @@ class ActivityStream(SubscriberMixin):
             # is actually newer than the last one.
             latest_activity = get_latest_activity(activity, last_activity)
             if latest_activity != activity:
+                _LOGGER.debug(
+                    "Skipping activity %s for device %s as it is not newer than the last one: %s",
+                    activity,
+                    device_id,
+                    last_activity,
+                )
                 continue
 
             device_activities[activity_type] = activity

--- a/yalexs/manager/data.py
+++ b/yalexs/manager/data.py
@@ -168,22 +168,27 @@ class YaleXSData(SubscriberMixin):
         self, device_id: str, date_time: datetime, message: dict[str, Any]
     ) -> None:
         """Process a push message."""
+        _LOGGER.debug("async_push_message: %s %s", device_id, message)
         device = self.get_device_detail(device_id)
         activities = activities_from_pubnub_message(device, date_time, message)
         activity_stream = self.activity_stream
         if activities and activity_stream.async_process_newer_device_activities(
             activities
         ):
-            _LOGGER.debug("async_push_message: %s for %s", device_id, activities)
+            _LOGGER.debug(
+                "async_push_message activities: %s for %s", device_id, activities
+            )
             self.async_signal_device_id_update(device.device_id)
             for activity in activities:
                 # Don't trigger a house refresh if the activity is a status update
                 # to avoid unnecessary API calls.
                 if activity.is_status:
-                    _LOGGER.debug("async_push_message: %s is status update", activity)
+                    _LOGGER.debug(
+                        "async_push_message activity: %s is status update", activity
+                    )
                     continue
                 _LOGGER.debug(
-                    "async_push_message triggering refresh: %s for %s",
+                    "async_push_message activity triggering refresh: %s for %s",
                     device_id,
                     activity,
                 )

--- a/yalexs/manager/data.py
+++ b/yalexs/manager/data.py
@@ -174,11 +174,7 @@ class YaleXSData(SubscriberMixin):
         if activities and activity_stream.async_process_newer_device_activities(
             activities
         ):
-            _LOGGER.debug(
-                "async_signal_device_id_update (from push): %s for %s",
-                device_id,
-                activities,
-            )
+            _LOGGER.warning("async_push_message: %s for %s", device_id, activities)
             self.async_signal_device_id_update(device.device_id)
             activity_stream.async_schedule_house_id_refresh(device.house_id)
 

--- a/yalexs/manager/data.py
+++ b/yalexs/manager/data.py
@@ -174,9 +174,21 @@ class YaleXSData(SubscriberMixin):
         if activities and activity_stream.async_process_newer_device_activities(
             activities
         ):
-            _LOGGER.warning("async_push_message: %s for %s", device_id, activities)
+            _LOGGER.debug("async_push_message: %s for %s", device_id, activities)
             self.async_signal_device_id_update(device.device_id)
-            activity_stream.async_schedule_house_id_refresh(device.house_id)
+            for activity in activities:
+                # Don't trigger a house refresh if the activity is a status update
+                # to avoid unnecessary API calls.
+                if activity.is_status:
+                    _LOGGER.debug("async_push_message: %s is status update", activity)
+                    continue
+                _LOGGER.debug(
+                    "async_push_message triggering refresh: %s for %s",
+                    device_id,
+                    activity,
+                )
+                activity_stream.async_schedule_house_id_refresh(device.house_id)
+                break
 
     async def async_stop(self, *args: Any) -> None:
         """Stop the subscriptions."""

--- a/yalexs/manager/data.py
+++ b/yalexs/manager/data.py
@@ -191,11 +191,12 @@ class YaleXSData(SubscriberMixin):
         device = self.get_device_detail(device_id)
         activities = activities_from_pubnub_message(device, date_time, message)
         activity_stream = self.activity_stream
+        _LOGGER.debug("async_push_message activities: %s for %s", activities, device_id)
         if activities and activity_stream.async_process_newer_device_activities(
             activities
         ):
             _LOGGER.debug(
-                "async_push_message activities: %s for %s", device_id, activities
+                "async_push_message newer activities: %s for %s", device_id, activities
             )
             self.async_signal_device_id_update(device.device_id)
             for activity in activities:

--- a/yalexs/manager/data.py
+++ b/yalexs/manager/data.py
@@ -214,7 +214,7 @@ class YaleXSData(SubscriberMixin):
             return
 
         device = self.get_device_detail(device_id)
-        activities = activities_from_pubnub_message(device, date_time, message)
+        activities = activities_from_pubnub_message(device, date_time, message, source)
         activity_stream = self.activity_stream
         _LOGGER.debug("async_push_message activities: %s for %s", activities, device_id)
         if activities and activity_stream.async_process_newer_device_activities(

--- a/yalexs/manager/data.py
+++ b/yalexs/manager/data.py
@@ -174,6 +174,11 @@ class YaleXSData(SubscriberMixin):
         if activities and activity_stream.async_process_newer_device_activities(
             activities
         ):
+            _LOGGER.debug(
+                "async_signal_device_id_update (from push): %s for %s",
+                device_id,
+                activities,
+            )
             self.async_signal_device_id_update(device.device_id)
             activity_stream.async_schedule_house_id_refresh(device.house_id)
 

--- a/yalexs/manager/data.py
+++ b/yalexs/manager/data.py
@@ -168,6 +168,25 @@ class YaleXSData(SubscriberMixin):
         self, device_id: str, date_time: datetime, message: dict[str, Any]
     ) -> None:
         """Process a push message."""
+        try:
+            self._async_handle_push_message(device_id, date_time, message)
+        except Exception:
+            _LOGGER.exception(
+                "Error processing push message for device %s at %s: %s",
+                device_id,
+                date_time,
+                message,
+            )
+            # If we have an error, we want to continue processing other messages
+            return
+
+    def _async_handle_push_message(
+        self,
+        device_id: str,
+        date_time: datetime,
+        message: dict[str, Any],
+    ) -> None:
+        """Handle a push message."""
         _LOGGER.debug("async_push_message: %s %s", device_id, message)
         device = self.get_device_detail(device_id)
         activities = activities_from_pubnub_message(device, date_time, message)

--- a/yalexs/pubnub_activity.py
+++ b/yalexs/pubnub_activity.py
@@ -62,11 +62,11 @@ def activities_from_pubnub_message(  # noqa: C901
     info = message.get("info", {})
     context = info.get("context", {})
     accept_user = False
-    if "startDate" in context:
-        activity_dict["dateTime"] = _datetime_string_to_epoch(context["startDate"])
-        accept_user = True
-    elif "startTime" in info:
+    if "startTime" in info:
         activity_dict["dateTime"] = _datetime_string_to_epoch(info["startTime"])
+        accept_user = True
+    elif "startDate" in context:
+        activity_dict["dateTime"] = _datetime_string_to_epoch(context["startDate"])
         accept_user = True
     else:
         activity_dict["dateTime"] = date_time.timestamp() * 1000


### PR DESCRIPTION
## Summary

This PR addresses excessive API calls reported by the vendor for both August (PubNub) and Yale (WebSocket) smart locks by improving activity detection and deduplication.

### Key Changes

1. **Fixed timestamp handling for PubNub** - PubNub activities now use actual event time (`startTime`) instead of transaction start time (`context.startDate`), preventing identical activities with different timestamps from being seen as unique

2. **Added status update detection** - New `is_status` property identifies activities that are status updates rather than real operations, with special handling for Bluetooth/manual lock operations

3. **Added WebSocket state tracking** - Implemented deduplication for Yale WebSocket messages that send repeated lock/door states, preventing redundant API calls

### Technical Details

- Modified timestamp priority in `pubnub_activity.py` to prefer `info.startTime` over `context.startDate`
- Added `is_status` property to `Activity` class to identify status updates
- Added `calling_user` property to base `Activity` class for manual operation detection
- Implemented state tracking in `YaleXSData` to detect unchanged WebSocket messages
- Updated activity creation to pass source (PubNub/WebSocket) for proper status detection
- Fixed test expectations to match new timestamp behavior

### Impact

This significantly reduces unnecessary API calls by:
- Skipping duplicate WebSocket status messages
- Properly identifying status updates vs real lock operations
- Preventing timestamp-related activity duplication

## Test plan

- [x] Verified WebSocket duplicate messages are skipped
- [x] Confirmed real lock/unlock operations trigger appropriate API calls
- [x] Tested Bluetooth unlock operations are correctly identified as real operations
- [x] All tests pass with updated timestamp expectations

