### PR TITLE
test: verify ruff DTZ rules still flag deprecated datetime calls

### DIFF
--- a/tests/test_authenticator_async.py
+++ b/tests/test_authenticator_async.py
@@ -52,10 +52,8 @@ class TestAuthenticatorAsync(unittest.IsolatedAsyncioTestCase):
         mock_aioresponses,
         v_password,
         v_install_id,
-        expires_at=None,
+        expires_at=format_datetime(datetime.utcnow()),  # noqa: B008, DTZ003
     ):
-        if expires_at is None:
-            expires_at = format_datetime(datetime.now(timezone.utc))
         mock_aioresponses.post(
             ApiCommon(DEFAULT_BRAND).get_brand_url(API_GET_SESSION_URL),
             headers={"x-august-access-token": "access_token"},

--- a/yalexs/authenticator_common.py
+++ b/yalexs/authenticator_common.py
@@ -155,7 +155,7 @@ class AuthenticatorCommon:
             _LOGGER.warning("Did not find expected `exp' claim in JWT")
             return self._authentication
 
-        new_expiration = datetime.fromtimestamp(jwt_claims["exp"], tz=timezone.utc)
+        new_expiration = datetime.utcfromtimestamp(jwt_claims["exp"])  # noqa: DTZ004
         # The yale access api always returns expiresAt formatted as
         # ``%Y-%m-%dT%H:%M:%S.%fZ`` from the get_session api call, so we
         # store access_token_expires the same way for compatibility.


### PR DESCRIPTION
## What

Reverts #340 to confirm the broader `DTZ` rule selector introduced by #351 still catches `datetime.utcfromtimestamp` and `datetime.utcnow`; same coverage we relied on with the old per code selectors.

## How

Pure revert of c18be76; restores the noqa suppressions that were present before #340 so local hooks stay green, and adds B008 to the test side since the new `B` selector catches the function call in a default argument.

## Notes

Draft; not for merge, just to confirm CI behavior on the new ruleset.