### PR TITLE
fix: process delayed activities chronologically

### DIFF
--- a/tests/manager/test_activity.py
+++ b/tests/manager/test_activity.py
@@ -514,6 +514,33 @@ async def test_update_house_id_signals_subscribers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_house_id_signals_duplicate_activity_once() -> None:
+    """Duplicate activities within one API response are signalled once."""
+    stream, _api, async_get = _build_stream()
+    activity_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    first = _make_activity(
+        "dev-1",
+        ActivityType.LOCK_OPERATION,
+        activity_time,
+        action="lock",
+    )
+    duplicate = _make_activity(
+        "dev-1",
+        ActivityType.LOCK_OPERATION,
+        activity_time,
+        action="lock",
+    )
+    async_get.return_value = [first, duplicate]
+    callback = MagicMock()
+    stream.async_subscribe_device_id("dev-1", callback)
+
+    await stream._async_update_house_id("house")
+
+    callback.assert_called_once()
+    stream.async_stop()
+
+
+@pytest.mark.asyncio
 async def test_process_newer_skips_duplicate_activity() -> None:
     """An identical activity already stored is not re-emitted."""
     stream, *_ = _build_stream()
@@ -557,6 +584,57 @@ async def test_process_newer_stores_new_activity() -> None:
     updated = stream.async_process_newer_device_activities([newer])
     assert updated == {"dev"}
     assert stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] is newer
+
+
+@pytest.mark.asyncio
+async def test_update_house_id_emits_delayed_activities_in_chronological_order() -> (
+    None
+):
+    """All unseen activities newer than the pre-poll watermark are emitted."""
+    stream, _api, async_get = _build_stream()
+    watermark_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    watermark = _make_activity(
+        "dev",
+        ActivityType.LOCK_OPERATION,
+        watermark_time,
+        action="lock",
+    )
+    returned_watermark = _make_activity(
+        "dev",
+        ActivityType.LOCK_OPERATION,
+        watermark_time,
+        action="lock",
+    )
+    delayed_unlock = _make_activity(
+        "dev",
+        ActivityType.LOCK_OPERATION,
+        watermark_time + timedelta(minutes=1),
+        action="unlock",
+    )
+    newer_lock = _make_activity(
+        "dev",
+        ActivityType.LOCK_OPERATION,
+        watermark_time + timedelta(hours=2),
+        action="lock",
+    )
+    stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] = watermark
+    async_get.return_value = [newer_lock, delayed_unlock, returned_watermark]
+
+    emitted_actions: list[str] = []
+    stream.async_subscribe_device_id(
+        "dev",
+        lambda: emitted_actions.append(
+            stream.get_latest_device_activity(
+                "dev", {ActivityType.LOCK_OPERATION}
+            ).action
+        ),
+    )
+
+    await stream._async_update_house_id("house")
+
+    assert emitted_actions == ["unlock", "lock"]
+    assert stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] is newer_lock
+    stream.async_stop()
 
 
 @pytest.mark.asyncio

--- a/tests/manager/test_activity.py
+++ b/tests/manager/test_activity.py
@@ -638,6 +638,94 @@ async def test_update_house_id_emits_delayed_activities_in_chronological_order()
 
 
 @pytest.mark.asyncio
+async def test_update_house_id_sorts_across_devices_independently() -> None:
+    """A single response interleaving devices updates each watermark on its own."""
+    stream, _api, async_get = _build_stream()
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    a_watermark = _make_activity("dev-a", ActivityType.LOCK_OPERATION, base, "lock")
+    stream._latest_activities["dev-a"][ActivityType.LOCK_OPERATION] = a_watermark
+
+    a_unlock = _make_activity(
+        "dev-a", ActivityType.LOCK_OPERATION, base + timedelta(minutes=5), "unlock"
+    )
+    a_lock = _make_activity(
+        "dev-a", ActivityType.LOCK_OPERATION, base + timedelta(minutes=10), "lock"
+    )
+    b_lock = _make_activity(
+        "dev-b", ActivityType.LOCK_OPERATION, base + timedelta(minutes=7), "lock"
+    )
+    # Returned out of order and interleaved between the two devices.
+    async_get.return_value = [a_lock, b_lock, a_unlock]
+
+    emitted: list[tuple[str, str]] = []
+    for dev_id in ("dev-a", "dev-b"):
+        stream.async_subscribe_device_id(
+            dev_id,
+            lambda d=dev_id: emitted.append(
+                (
+                    d,
+                    stream.get_latest_device_activity(
+                        d, {ActivityType.LOCK_OPERATION}
+                    ).action,
+                )
+            ),
+        )
+
+    await stream._async_update_house_id("house")
+
+    # Each device observes its own activities, ordered by the global timeline.
+    assert emitted == [("dev-a", "unlock"), ("dev-b", "lock"), ("dev-a", "lock")]
+    assert stream._latest_activities["dev-a"][ActivityType.LOCK_OPERATION] is a_lock
+    assert stream._latest_activities["dev-b"][ActivityType.LOCK_OPERATION] is b_lock
+    stream.async_stop()
+
+
+@pytest.mark.asyncio
+async def test_update_house_id_tracks_activity_types_separately() -> None:
+    """Different activity types for one device are stored in their own slots."""
+    stream, _api, async_get = _build_stream()
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    door = _make_activity(
+        "dev", ActivityType.DOOR_OPERATION, base + timedelta(minutes=3), "doorclosed"
+    )
+    unlock = _make_activity(
+        "dev", ActivityType.LOCK_OPERATION, base + timedelta(minutes=5), "unlock"
+    )
+    async_get.return_value = [unlock, door]
+    callback = MagicMock()
+    stream.async_subscribe_device_id("dev", callback)
+
+    await stream._async_update_house_id("house")
+
+    assert callback.call_count == 2
+    assert stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] is unlock
+    assert stream._latest_activities["dev"][ActivityType.DOOR_OPERATION] is door
+    stream.async_stop()
+
+
+@pytest.mark.asyncio
+async def test_process_newer_stores_newest_from_out_of_order_batch() -> None:
+    """The push path sorts a batch and leaves the newest activity stored."""
+    stream, *_ = _build_stream()
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] = _make_activity(
+        "dev", ActivityType.LOCK_OPERATION, base, "lock"
+    )
+    delayed_unlock = _make_activity(
+        "dev", ActivityType.LOCK_OPERATION, base + timedelta(minutes=5), "unlock"
+    )
+    newest_lock = _make_activity(
+        "dev", ActivityType.LOCK_OPERATION, base + timedelta(minutes=10), "lock"
+    )
+    # Newest first, so the delayed unlock trails the lock in the batch.
+    updated = stream.async_process_newer_device_activities(
+        [newest_lock, delayed_unlock]
+    )
+    assert updated == {"dev"}
+    assert stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] is newest_lock
+
+
+@pytest.mark.asyncio
 async def test_activity_limit_switches_after_first_update() -> None:
     """Before the first update the catch-up limit is used; afterwards the stream limit."""
     stream, *_ = _build_stream()

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections import defaultdict
 from collections.abc import Iterator
+from operator import attrgetter
 
 from aiohttp import ClientError
 
@@ -298,7 +299,7 @@ class ActivityStream(SubscriberMixin):
         and must be consumed lazily when subscribers need to observe every update.
         """
         latest_activities = self._latest_activities
-        for activity in sorted(activities, key=lambda item: item.activity_start_time):
+        for activity in sorted(activities, key=attrgetter("activity_start_time")):
             device_id = activity.device_id
             activity_type = activity.activity_type
             device_activities = latest_activities[device_id]

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import defaultdict
+from collections.abc import Iterator
 
 from aiohttp import ClientError
 
@@ -270,7 +271,8 @@ class ActivityStream(SubscriberMixin):
         _LOGGER.debug(
             "Completed retrieving device activities for house id %s", house_id
         )
-        for device_id in self.async_process_newer_device_activities(activities):
+        for activity in self._iter_newer_device_activities(activities):
+            device_id = activity.device_id
             _LOGGER.debug(
                 "async_signal_device_id_update (from activity stream): %s",
                 device_id,
@@ -281,15 +283,29 @@ class ActivityStream(SubscriberMixin):
         self, activities: list[Activity]
     ) -> set[str]:
         """Process activities if they are newer than the last one."""
-        updated_device_ids: set[str] = set()
+        return {
+            activity.device_id
+            for activity in self._iter_newer_device_activities(activities)
+        }
+
+    def _iter_newer_device_activities(
+        self, activities: list[Activity]
+    ) -> Iterator[Activity]:
+        """Process and yield newer activities in chronological order."""
         latest_activities = self._latest_activities
+        previous_activities = {
+            (activity.device_id, activity.activity_type): latest_activities[
+                activity.device_id
+            ][activity.activity_type]
+            for activity in activities
+        }
+        newer_activities: list[Activity] = []
         for activity in activities:
             device_id = activity.device_id
             activity_type = activity.activity_type
-            device_activities = latest_activities[device_id]
             # Ignore activities that are older than the latest one unless it is a non
             # locking or unlocking activity with the exact same start time.
-            last_activity = device_activities[activity_type]
+            last_activity = previous_activities[(device_id, activity_type)]
             # The activity stream can have duplicate activities. So we need
             # to call get_latest_activity to figure out if if the activity
             # is actually newer than the last one.
@@ -303,7 +319,16 @@ class ActivityStream(SubscriberMixin):
                 )
                 continue
 
-            device_activities[activity_type] = activity
-            updated_device_ids.add(device_id)
+            newer_activities.append(activity)
 
-        return updated_device_ids
+        for activity in sorted(
+            newer_activities, key=lambda item: item.activity_start_time
+        ):
+            device_id = activity.device_id
+            activity_type = activity.activity_type
+            device_activities = latest_activities[device_id]
+            last_activity = device_activities[activity_type]
+            if get_latest_activity(activity, last_activity) != activity:
+                continue
+            device_activities[activity_type] = activity
+            yield activity

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -292,7 +292,11 @@ class ActivityStream(SubscriberMixin):
     def _iter_newer_device_activities(
         self, activities: list[Activity]
     ) -> Iterator[Activity]:
-        """Process and yield newer activities in chronological order."""
+        """Store and yield newer activities chronologically, one activity at a time.
+
+        This iterator mutates ``_latest_activities`` immediately before each yield
+        and must be consumed lazily when subscribers need to observe every update.
+        """
         latest_activities = self._latest_activities
         for activity in sorted(activities, key=lambda item: item.activity_start_time):
             device_id = activity.device_id

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -271,6 +271,7 @@ class ActivityStream(SubscriberMixin):
         _LOGGER.debug(
             "Completed retrieving device activities for house id %s", house_id
         )
+        # Signal between yields so subscribers observe every activity in order.
         for activity in self._iter_newer_device_activities(activities):
             device_id = activity.device_id
             _LOGGER.debug(
@@ -293,42 +294,18 @@ class ActivityStream(SubscriberMixin):
     ) -> Iterator[Activity]:
         """Process and yield newer activities in chronological order."""
         latest_activities = self._latest_activities
-        previous_activities = {
-            (activity.device_id, activity.activity_type): latest_activities[
-                activity.device_id
-            ][activity.activity_type]
-            for activity in activities
-        }
-        newer_activities: list[Activity] = []
-        for activity in activities:
+        for activity in sorted(activities, key=lambda item: item.activity_start_time):
             device_id = activity.device_id
             activity_type = activity.activity_type
-            # Ignore activities that are older than the latest one unless it is a non
-            # locking or unlocking activity with the exact same start time.
-            last_activity = previous_activities[(device_id, activity_type)]
-            # The activity stream can have duplicate activities. So we need
-            # to call get_latest_activity to figure out if if the activity
-            # is actually newer than the last one.
-            latest_activity = get_latest_activity(activity, last_activity)
-            if latest_activity != activity:
+            device_activities = latest_activities[device_id]
+            last_activity = device_activities[activity_type]
+            if get_latest_activity(activity, last_activity) != activity:
                 _LOGGER.debug(
                     "Skipping activity %s for device %s as it is not newer than the last one: %s",
                     activity,
                     device_id,
                     last_activity,
                 )
-                continue
-
-            newer_activities.append(activity)
-
-        for activity in sorted(
-            newer_activities, key=lambda item: item.activity_start_time
-        ):
-            device_id = activity.device_id
-            activity_type = activity.activity_type
-            device_activities = latest_activities[device_id]
-            last_activity = device_activities[activity_type]
-            if get_latest_activity(activity, last_activity) != activity:
                 continue
             device_activities[activity_type] = activity
             yield activity


### PR DESCRIPTION
### Problem
See related investigation: https://github.com/home-assistant/core/issues/153236

The activities API returns activities newest-first. ActivityStream processes each activity while also immediately updating its latest-activity timestamp.

This can discard legitimate delayed activities from the same response.

For example, assume the previously processed watermark is 09:13:
```
API response, newest-first:

11:42 one_touch_lock
09:14 pin_unlock by Maria
09:13 previously processed lock
```

Current behavior:
```
Accept 11:42 lock
Update watermark to 11:42
Reject 09:14 unlock because it is now older than the watermark
```

The 09:14 event was never previously processed, but is treated as stale because the watermark changed while traversing the response.

This was observed with Yale/August locks where operator information was not available during the initial activity polls. A later lock operation triggered another poll that returned both the delayed named unlock and the newer lock.

### Fix
This change:

1. Snapshots the latest activity for each device/activity type before processing the response.
2. Finds all activities newer than that pre-poll watermark.
3. Processes those activities chronologically.
4. Signals subscribers after each accepted activity.

The example above therefore emits:
```
09:14 pin_unlock by Maria
11:42 one_touch_lock
```

`async_process_newer_device_activities()` retains its existing interface for individual push-message processing.

#### Why timestamps rather than event IDs?
An alternative would be to retain a set of processed activity IDs and process every previously unseen ID.

That could handle additional cases such as:

- Activities published after the watermark has already advanced in an earlier poll.
- Distinct activities with identical timestamps.
- Server-side timestamp corrections or unusual reordering.

However, ID tracking would require retained history, expiry rules, and additional state management.

The reproduced failure does not require ID tracking: every delayed activity was newer than the watermark that existed before its API response. The problem was solely that the watermark advanced during traversal of a newest-first batch.

This change therefore keeps the existing timestamp-based design and addresses the demonstrated failure without introducing a processed-ID ledger.

#### Caveats

- Activities older than the watermark at the start of a poll remain ignored. This is existing behavior and is not made worse by this change.
- Activities sharing an identical timestamp retain the existing get_latest_activity() semantics.
- The push-message path is intentionally unchanged.
- This does not extend the activity polling window. It ensures delayed activities are delivered when a subsequent poll eventually returns them.
- Multiple recovered activities now produce multiple subscriber notifications rather than only exposing the final cached activity.

### Testing
Added regression coverage for:

- A newest-first response containing a newer lock, a delayed unlock, and the previous watermark.
- Chronological subscriber notifications for all newly discovered activities.
- Duplicate activities within one API response being signaled only once.