### PR TITLE
fix: process delayed activities chronologically

### DIFF
--- a/tests/manager/test_activity.py
+++ b/tests/manager/test_activity.py
@@ -514,6 +514,33 @@ async def test_update_house_id_signals_subscribers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_house_id_signals_duplicate_activity_once() -> None:
+    """Duplicate activities within one API response are signalled once."""
+    stream, _api, async_get = _build_stream()
+    activity_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    first = _make_activity(
+        "dev-1",
+        ActivityType.LOCK_OPERATION,
+        activity_time,
+        action="lock",
+    )
+    duplicate = _make_activity(
+        "dev-1",
+        ActivityType.LOCK_OPERATION,
+        activity_time,
+        action="lock",
+    )
+    async_get.return_value = [first, duplicate]
+    callback = MagicMock()
+    stream.async_subscribe_device_id("dev-1", callback)
+
+    await stream._async_update_house_id("house")
+
+    callback.assert_called_once()
+    stream.async_stop()
+
+
+@pytest.mark.asyncio
 async def test_process_newer_skips_duplicate_activity() -> None:
     """An identical activity already stored is not re-emitted."""
     stream, *_ = _build_stream()
@@ -557,6 +584,57 @@ async def test_process_newer_stores_new_activity() -> None:
     updated = stream.async_process_newer_device_activities([newer])
     assert updated == {"dev"}
     assert stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] is newer
+
+
+@pytest.mark.asyncio
+async def test_update_house_id_emits_delayed_activities_in_chronological_order() -> (
+    None
+):
+    """All unseen activities newer than the pre-poll watermark are emitted."""
+    stream, _api, async_get = _build_stream()
+    watermark_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    watermark = _make_activity(
+        "dev",
+        ActivityType.LOCK_OPERATION,
+        watermark_time,
+        action="lock",
+    )
+    returned_watermark = _make_activity(
+        "dev",
+        ActivityType.LOCK_OPERATION,
+        watermark_time,
+        action="lock",
+    )
+    delayed_unlock = _make_activity(
+        "dev",
+        ActivityType.LOCK_OPERATION,
+        watermark_time + timedelta(minutes=1),
+        action="unlock",
+    )
+    newer_lock = _make_activity(
+        "dev",
+        ActivityType.LOCK_OPERATION,
+        watermark_time + timedelta(hours=2),
+        action="lock",
+    )
+    stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] = watermark
+    async_get.return_value = [newer_lock, delayed_unlock, returned_watermark]
+
+    emitted_actions: list[str] = []
+    stream.async_subscribe_device_id(
+        "dev",
+        lambda: emitted_actions.append(
+            stream.get_latest_device_activity(
+                "dev", {ActivityType.LOCK_OPERATION}
+            ).action
+        ),
+    )
+
+    await stream._async_update_house_id("house")
+
+    assert emitted_actions == ["unlock", "lock"]
+    assert stream._latest_activities["dev"][ActivityType.LOCK_OPERATION] is newer_lock
+    stream.async_stop()
 
 
 @pytest.mark.asyncio

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections import defaultdict
 from collections.abc import Iterator
+from operator import attrgetter
 
 from aiohttp import ClientError
 
@@ -298,7 +299,7 @@ class ActivityStream(SubscriberMixin):
         and must be consumed lazily when subscribers need to observe every update.
         """
         latest_activities = self._latest_activities
-        for activity in sorted(activities, key=lambda item: item.activity_start_time):
+        for activity in sorted(activities, key=attrgetter("activity_start_time")):
             device_id = activity.device_id
             activity_type = activity.activity_type
             device_activities = latest_activities[device_id]

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import defaultdict
+from collections.abc import Iterator
 
 from aiohttp import ClientError
 
@@ -270,7 +271,8 @@ class ActivityStream(SubscriberMixin):
         _LOGGER.debug(
             "Completed retrieving device activities for house id %s", house_id
         )
-        for device_id in self.async_process_newer_device_activities(activities):
+        for activity in self._iter_newer_device_activities(activities):
+            device_id = activity.device_id
             _LOGGER.debug(
                 "async_signal_device_id_update (from activity stream): %s",
                 device_id,
@@ -281,15 +283,29 @@ class ActivityStream(SubscriberMixin):
         self, activities: list[Activity]
     ) -> set[str]:
         """Process activities if they are newer than the last one."""
-        updated_device_ids: set[str] = set()
+        return {
+            activity.device_id
+            for activity in self._iter_newer_device_activities(activities)
+        }
+
+    def _iter_newer_device_activities(
+        self, activities: list[Activity]
+    ) -> Iterator[Activity]:
+        """Process and yield newer activities in chronological order."""
         latest_activities = self._latest_activities
+        previous_activities = {
+            (activity.device_id, activity.activity_type): latest_activities[
+                activity.device_id
+            ][activity.activity_type]
+            for activity in activities
+        }
+        newer_activities: list[Activity] = []
         for activity in activities:
             device_id = activity.device_id
             activity_type = activity.activity_type
-            device_activities = latest_activities[device_id]
             # Ignore activities that are older than the latest one unless it is a non
             # locking or unlocking activity with the exact same start time.
-            last_activity = device_activities[activity_type]
+            last_activity = previous_activities[(device_id, activity_type)]
             # The activity stream can have duplicate activities. So we need
             # to call get_latest_activity to figure out if if the activity
             # is actually newer than the last one.
@@ -303,7 +319,16 @@ class ActivityStream(SubscriberMixin):
                 )
                 continue
 
-            device_activities[activity_type] = activity
-            updated_device_ids.add(device_id)
+            newer_activities.append(activity)
 
-        return updated_device_ids
+        for activity in sorted(
+            newer_activities, key=lambda item: item.activity_start_time
+        ):
+            device_id = activity.device_id
+            activity_type = activity.activity_type
+            device_activities = latest_activities[device_id]
+            last_activity = device_activities[activity_type]
+            if get_latest_activity(activity, last_activity) != activity:
+                continue
+            device_activities[activity_type] = activity
+            yield activity

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -292,7 +292,11 @@ class ActivityStream(SubscriberMixin):
     def _iter_newer_device_activities(
         self, activities: list[Activity]
     ) -> Iterator[Activity]:
-        """Process and yield newer activities in chronological order."""
+        """Store and yield newer activities chronologically, one activity at a time.
+
+        This iterator mutates ``_latest_activities`` immediately before each yield
+        and must be consumed lazily when subscribers need to observe every update.
+        """
         latest_activities = self._latest_activities
         for activity in sorted(activities, key=lambda item: item.activity_start_time):
             device_id = activity.device_id

--- a/yalexs/manager/activity.py
+++ b/yalexs/manager/activity.py
@@ -271,6 +271,7 @@ class ActivityStream(SubscriberMixin):
         _LOGGER.debug(
             "Completed retrieving device activities for house id %s", house_id
         )
+        # Signal between yields so subscribers observe every activity in order.
         for activity in self._iter_newer_device_activities(activities):
             device_id = activity.device_id
             _LOGGER.debug(
@@ -293,42 +294,18 @@ class ActivityStream(SubscriberMixin):
     ) -> Iterator[Activity]:
         """Process and yield newer activities in chronological order."""
         latest_activities = self._latest_activities
-        previous_activities = {
-            (activity.device_id, activity.activity_type): latest_activities[
-                activity.device_id
-            ][activity.activity_type]
-            for activity in activities
-        }
-        newer_activities: list[Activity] = []
-        for activity in activities:
+        for activity in sorted(activities, key=lambda item: item.activity_start_time):
             device_id = activity.device_id
             activity_type = activity.activity_type
-            # Ignore activities that are older than the latest one unless it is a non
-            # locking or unlocking activity with the exact same start time.
-            last_activity = previous_activities[(device_id, activity_type)]
-            # The activity stream can have duplicate activities. So we need
-            # to call get_latest_activity to figure out if if the activity
-            # is actually newer than the last one.
-            latest_activity = get_latest_activity(activity, last_activity)
-            if latest_activity != activity:
+            device_activities = latest_activities[device_id]
+            last_activity = device_activities[activity_type]
+            if get_latest_activity(activity, last_activity) != activity:
                 _LOGGER.debug(
                     "Skipping activity %s for device %s as it is not newer than the last one: %s",
                     activity,
                     device_id,
                     last_activity,
                 )
-                continue
-
-            newer_activities.append(activity)
-
-        for activity in sorted(
-            newer_activities, key=lambda item: item.activity_start_time
-        ):
-            device_id = activity.device_id
-            activity_type = activity.activity_type
-            device_activities = latest_activities[device_id]
-            last_activity = device_activities[activity_type]
-            if get_latest_activity(activity, last_activity) != activity:
                 continue
             device_activities[activity_type] = activity
             yield activity


### PR DESCRIPTION
### Problem

The activities API returns activities newest first, and the stream advances its watermark while walking the batch. A delayed activity in the same response can end up older than the freshly raised watermark and get dropped, even though it was never processed before.

### Fix

Snapshot the latest activity per device and activity type before processing, find everything newer than that pre poll watermark, process those chronologically, and signal subscribers after each accepted activity. The push message path keeps its existing interface. The sort key uses operator.attrgetter.

### Testing

Added regression coverage for a newest first response containing a newer lock, a delayed unlock, and the previous watermark; chronological subscriber notifications for all newly discovered activities; duplicate activities within one response being signalled only once.
