### PR TITLE
fix: isolate subscriber callback failures

### DIFF
--- a/tests/manager/test_subscriber.py
+++ b/tests/manager/test_subscriber.py
@@ -103,6 +103,24 @@ async def test_signal_device_id_update_invokes_callbacks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_signal_device_id_update_continues_when_a_callback_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sub = _Subscriber(timedelta(seconds=30))
+    raising = MagicMock(side_effect=RuntimeError("boom"))
+    other = MagicMock()
+    sub.async_subscribe_device_id("lock1", raising)
+    sub.async_subscribe_device_id("lock1", other)
+
+    # A raising subscriber must not propagate or starve the other callbacks.
+    sub.async_signal_device_id_update("lock1")
+
+    raising.assert_called_once_with()
+    other.assert_called_once_with()
+    assert "Error calling update callback for device lock1" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_signal_device_id_update_unknown_device_is_noop() -> None:
     sub = _Subscriber(timedelta(seconds=30))
     # No subscribers at all — must not raise.

--- a/tests/manager/test_subscriber.py
+++ b/tests/manager/test_subscriber.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import timedelta
 from unittest.mock import MagicMock
 
@@ -113,11 +114,31 @@ async def test_signal_device_id_update_continues_when_a_callback_raises(
     sub.async_subscribe_device_id("lock1", other)
 
     # A raising subscriber must not propagate or starve the other callbacks.
-    sub.async_signal_device_id_update("lock1")
+    with caplog.at_level(logging.ERROR, logger="yalexs.manager.subscriber"):
+        sub.async_signal_device_id_update("lock1")
 
     raising.assert_called_once_with()
     other.assert_called_once_with()
     assert "Error calling update callback for device lock1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_signal_device_id_update_allows_callback_to_unsubscribe() -> None:
+    sub = _Subscriber(timedelta(seconds=30))
+    other = MagicMock()
+
+    def _unsubscribe_self() -> None:
+        sub.async_unsubscribe_device_id("lock1", _unsubscribe_self)
+
+    sub.async_subscribe_device_id("lock1", _unsubscribe_self)
+    sub.async_subscribe_device_id("lock1", other)
+
+    # Mutating the subscription set from within a callback must not raise
+    # RuntimeError or skip the remaining subscribers.
+    sub.async_signal_device_id_update("lock1")
+
+    other.assert_called_once_with()
+    assert _unsubscribe_self not in sub._subscriptions.get("lock1", set())
 
 
 @pytest.mark.asyncio

--- a/yalexs/manager/subscriber.py
+++ b/yalexs/manager/subscriber.py
@@ -98,4 +98,18 @@ class SubscriberMixin(ABC):
     def async_signal_device_id_update(self, device_id: str) -> None:
         """Call the callbacks for a device_id."""
         for update_callback in self._subscriptions.get(device_id, ()):
+            self._async_call_update_callback(update_callback, device_id)
+
+    def _async_call_update_callback(
+        self, update_callback: Callable[[], None], device_id: str
+    ) -> None:
+        """Call a single subscriber callback, isolating its failures.
+
+        A misbehaving subscriber must not stop the others from being notified,
+        and callers signal mid-batch, so a raise here would otherwise abort the
+        remaining updates in the same poll.
+        """
+        try:
             update_callback()
+        except Exception:
+            _LOGGER.exception("Error calling update callback for device %s", device_id)

--- a/yalexs/manager/subscriber.py
+++ b/yalexs/manager/subscriber.py
@@ -97,7 +97,9 @@ class SubscriberMixin(ABC):
 
     def async_signal_device_id_update(self, device_id: str) -> None:
         """Call the callbacks for a device_id."""
-        for update_callback in self._subscriptions.get(device_id, ()):
+        # Snapshot the set so a callback that subscribes or unsubscribes while
+        # being notified cannot mutate it mid-iteration and raise RuntimeError.
+        for update_callback in tuple(self._subscriptions.get(device_id, ())):
             self._async_call_update_callback(update_callback, device_id)
 
     def _async_call_update_callback(


### PR DESCRIPTION
### Problem

`async_signal_device_id_update` calls each subscriber callback with no guard. If one callback raises synchronously, the exception propagates out and the remaining subscribers for that device are never notified. The activity stream now signals subscribers mid batch while advancing watermarks, so a raise there can also abort the rest of the poll and leave later activities unprocessed until the next fetch.

### Fix

Isolate each callback so a raising subscriber is logged and the others still run. This keeps both the existing per device signalling and the interleaved activity stream signalling robust.

### Testing

Added a subscriber test asserting that when one callback raises, the other still fires and the error is logged rather than propagated.
